### PR TITLE
Unrolled merged list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .vscode
 main
-kri
+kri*
 gen.c
 te*
 mem_usg.sh

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ CXX = g++ --std=c++20
 #  -lncursesw		Links to ncurses library for wide characters (unicode)
 
 OPTIM = -O3 -s -flto -march=native -DRELEASE
-SIZE  = -Os -s -flto -fdata-sections -ffunction-sections -Wl,--gc-sections
 DEBUG = -g #-DDEBUG
 CXXFLAGS = -Wall -Wextra -pedantic-errors $(OPTIM) -DHIGHLIGHT # Debug only
 #CXXFLAGS = -Wall -Wextra -pedantic $(OPTIM) -DHIGHLIGHT

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ CXX = g++ --std=c++20
 #  -lncursesw		Links to ncurses library for wide characters (unicode)
 
 OPTIM = -O3 -s -flto -march=native -DRELEASE
-SIZE = -Os -s -flto -fdata-sections -ffunction-sections -Wl,--gc-sections
+SIZE  = -Os -s -flto -fdata-sections -ffunction-sections -Wl,--gc-sections
 DEBUG = -g #-DDEBUG
-#CXXFLAGS = -Wall -Wextra -pedantic-errors $(DEBUG) -DHIGHLIGHT -lncursesw # Debug only
-CXXFLAGS = -Wall -Wextra -pedantic $(OPTIM) -DHIGHLIGHT -lncursesw
+CXXFLAGS = -Wall -Wextra -pedantic-errors $(DEBUG) -DHIGHLIGHT # Debug only
+#CXXFLAGS = -Wall -Wextra -pedantic $(OPTIM) -DHIGHLIGHT
 
 # the build target executable
 TARGET = kri
@@ -24,11 +24,12 @@ PATHT = /usr/bin/
 SRCS = main.cpp \
 	utils/key_func.cpp \
 	utils/io.cpp \
+	ds/gapbuffer.cpp \
+	ds/merged_unrolled-list.cpp \
 	screen/highlight.cpp \
 	screen/init.cpp \
-	utils/sizes.cpp \
-	utils/gapbuffer.cpp \
-	utils/search.cpp
+	utils/sizes.cpp 
+#	utils/search.cpp
 
 # object files
 OBJS = $(SRCS:.cpp=.o)
@@ -38,7 +39,7 @@ build: $(TARGET)
 
 # link
 $(TARGET): $(OBJS)
-	$(CXX) -o $@ $^ $(CXXFLAGS)
+	$(CXX) -o $@ $^ $(CXXFLAGS) -lncursesw
 
 # compile
 %.o: %.cpp

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ SRCS = main.cpp \
 	ds/merged_unrolled-list.cpp \
 	screen/highlight.cpp \
 	screen/init.cpp \
-	utils/sizes.cpp 
-#	utils/search.cpp
+	utils/sizes.cpp \
+	utils/search.cpp
 
 # object files
 OBJS = $(SRCS:.cpp=.o)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CXX = g++ --std=c++20
 OPTIM = -O3 -s -flto -march=native -DRELEASE
 SIZE  = -Os -s -flto -fdata-sections -ffunction-sections -Wl,--gc-sections
 DEBUG = -g #-DDEBUG
-CXXFLAGS = -Wall -Wextra -pedantic-errors $(DEBUG) -DHIGHLIGHT # Debug only
+CXXFLAGS = -Wall -Wextra -pedantic-errors $(OPTIM) -DHIGHLIGHT # Debug only
 #CXXFLAGS = -Wall -Wextra -pedantic $(OPTIM) -DHIGHLIGHT
 
 # the build target executable

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CXX = g++ --std=c++20
 
 OPTIM = -O3 -s -flto -march=native -DRELEASE
 DEBUG = -g #-DDEBUG
-CXXFLAGS = -Wall -Wextra -pedantic-errors $(OPTIM) -DHIGHLIGHT # Debug only
+CXXFLAGS = -Wall -Wextra -pedantic-errors $(DEBUG) -DHIGHLIGHT # Debug only
 #CXXFLAGS = -Wall -Wextra -pedantic $(OPTIM) -DHIGHLIGHT
 
 # the build target executable

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ kri # ask for filename on save file operation
 * Exit: Ctrl-X
 * Go to start of line: Ctrl-A
 * Go to end of line: Ctrl-E
-* Open other file Alt-R
 * Delete line: Ctrl-K
 * Go to previous/next word: Shift + Left/Right arrow
 * Enter built-in terminal: Alt-C

--- a/ds/gapbuffer.cpp
+++ b/ds/gapbuffer.cpp
@@ -41,24 +41,19 @@ void mv_curs(gap_buf &a, ulong pos)
 	a.set_gps(pos);
 }
 
-void insert_c(gap_buf &a, ulong pos, char ch)
+void insert_c(gap_buf &a, char ch)
 {
 	if (a.gps() >= a.gpe()) [[unlikely]]
 		resize(a, __bit_ceil(a.cpt() + 1));
-	if (!ingap(a, pos))
-		mv_curs(a, pos);
-	a[pos] = ch;
+	a[a.gps()] = ch;
 	a.set_gps(a.gps() + 1);
 }
 
-void insert_s(gap_buf &a, ulong pos, const char *str, ulong len)
+void insert_s(gap_buf &a, const char *str, ulong len)
 {
-	// TODO: are both checks needed? (checked indirectly?)
 	if (a.gps() + len >= a.gpe() + 1) [[unlikely]]
 		resize(a, __bit_ceil(a.len() + len + 2));
-	if (gaplen(a) <= len)
-		mv_curs(a, pos);
-	memcpy(a.buffer() + pos, str, len);
+	memcpy(a.buffer() + a.gps(), str, len);
 	a.set_gps(a.gps() + len);
 }
 

--- a/ds/gapbuffer.cpp
+++ b/ds/gapbuffer.cpp
@@ -6,91 +6,108 @@ uint lnbf_cpt;
 
 void init(gap_buf &a)
 {
-	a.lo = a.hi = 0;
-	char *buffer = (char*)malloc(array_size);
-	a.set_buf(buffer);
-	a.set_gpe(array_size - 1);
-	a.set_cpt(array_size);
+	a.gps = 0;
+	a.ptr = 0x300000000000000;
+	a.gpe = array_size - 1;
+	char *buf = (char*)malloc(array_size);
+	a.set_buf(buf);
 }
 
-void resize(gap_buf &a, ulong size)
+void _resize_common(gap_buf &a, uint nsz, uint psz)
 {
 	char *buffer = a.buffer();
-	buffer = (char*)realloc(buffer, size);
+	buffer = (char*)realloc(buffer, nsz);
 	a.set_buf(buffer);
-	if (a.gpe() < a.cpt() - 1) { // copy after gap (newline + more)
-		memmove(a.buffer() + size - a.cpt() + a.gpe() + 1, a.buffer() + a.gpe() + 1, a.cpt() - a.gpe() - 1);
-		a.set_gpe(size - a.cpt() + a.gpe());
+	if (a.gpe < psz - 1) { // copy after gap (newline + more)
+		memmove(a.buffer() + nsz - psz + a.gpe + 1, a.buffer() + a.gpe + 1, psz - a.gpe - 1);
+		a.gpe = nsz - psz + a.gpe;
 	} else
-		a.set_gpe(size - 1);
-	a.set_cpt(size);
+		a.gpe = nsz - 1;
 }
 
-void mv_curs(gap_buf &a, ulong pos)
+void resize2fit(gap_buf &a, uint sz)
 {
-	if (a.gps() >= a.gpe() + 1) [[unlikely]]
-		resize(a, __bit_ceil(a.cpt() + 1));
-	if (pos > a.gps()) // move gap to right
-		memmove(a.buffer() + a.gps(), a.buffer() + a.gpe() + 1, pos - a.gps());
-	else if (pos < a.gps()) // move gap to left
-		memmove(a.buffer() + pos + gaplen(a), a.buffer() + pos, a.gps() - pos);
-	if (pos >= a.len())
-		a.set_gpe(a.cpt() - 1);
+	uint target;
+	if (sz > 29 * 0x1000000)
+		target = sz / 0x1000000;
 	else
-		a.set_gpe(a.gpe() + pos - a.gps());
-	a.set_gps(pos);
+		target = log2(sz);
+	_resize_common(a, sz, a.cpt());
+	a.set_cpt(target);
+}
+
+void resize_up(gap_buf &a)
+{
+	uint psz = a.cpt();
+	a.incr_cpt();
+	uint nsz = a.cpt();
+	_resize_common(a, nsz, psz);
+}
+
+void mv_curs(gap_buf &a, uint pos)
+{
+	if (a.gps >= a.gpe + 1) [[unlikely]]
+		resize_up(a);
+	if (pos > a.gps) // move gap to right
+		memmove(a.buffer() + a.gps, a.buffer() + a.gpe + 1, pos - a.gps);
+	else if (pos < a.gps) // move gap to left
+		memmove(a.buffer() + pos + gaplen(a), a.buffer() + pos, a.gps - pos);
+	if (pos >= a.len())
+		a.gpe = a.cpt() - 1;
+	else
+		a.gpe = a.gpe + pos - a.gps;
+	a.gps = pos;
 }
 
 void insert_c(gap_buf &a, char ch)
 {
-	if (a.gps() >= a.gpe()) [[unlikely]]
-		resize(a, __bit_ceil(a.cpt() + 1));
-	a[a.gps()] = ch;
-	a.set_gps(a.gps() + 1);
+	if (a.gps >= a.gpe) [[unlikely]]
+		resize_up(a);
+	a[a.gps] = ch;
+	a.gps++;
 }
 
-void insert_s(gap_buf &a, const char *str, ulong len)
+void insert_s(gap_buf &a, const char *str, uint len)
 {
-	if (a.gps() + len >= a.gpe() + 1) [[unlikely]]
-		resize(a, __bit_ceil(a.len() + len + 2));
-	memcpy(a.buffer() + a.gps(), str, len);
-	a.set_gps(a.gps() + len);
+	if (a.gps + len >= a.gpe + 1) [[unlikely]]
+		resize2fit(a, __bit_ceil(a.len() + len + 2));
+	memcpy(a.buffer() + a.gps, str, len);
+	a.gps += len;
 }
 
 void apnd_c(gap_buf &a, char ch)
 {
-	if (a.gps() >= a.gpe() + 1) [[unlikely]]
-		resize(a, __bit_ceil(a.cpt() + 1));
+	if (a.gps >= a.gpe + 1) [[unlikely]]
+		resize_up(a);
 	a[a.len()] = ch;
-	a.set_gps(a.gps() + 1);
+	a.gps++;
 }
-
-void apnd_s(gap_buf &a, const char *str, ulong size)
+void apnd_s(gap_buf &a, const char *str, uint size)
 {
-	if (a.gps() + size >= a.cpt()) [[unlikely]]
-		resize(a, __bit_ceil(a.len() + size + 2));
-	memcpy(a.buffer() + a.gps(), str, size);
-	a.set_gps(a.gps() + size);
+	if (a.gps + size >= a.cpt()) [[unlikely]]
+		resize2fit(a, __bit_ceil(a.len() + size + 2));
+	memcpy(a.buffer() + a.gps, str, size);
+	a.gps += size;
 }
 
 void apnd_s(gap_buf &a, const char *str)
 {
-	ulong i = a.len();
+	uint i = a.len();
 	while (str[i - a.len()] != 0) {
 		a[i] = str[i - a.len()];
 		if (++i == a.cpt())
-			resize(a, a.cpt() * 2); 
+			resize_up(a); 
 	}
-	a.set_gps(i);
+	a.gps += i;
 }
 
 void eras(gap_buf &a)
 {
-	if (a[a.gps() - 1] < 0) { // unicode
-		a.set_gps(a.gps() - 1);
+	if (a[a.gps - 1] < 0) { // unicode
+		a.gps--;
 		--ofx; // assumes this UTF-8 point is 2 bytes
 	}
-	a.set_gps(a.gps() - 1);
+	a.gps--;
 }
 
 #define error_check {\
@@ -111,19 +128,19 @@ void eras(gap_buf &a)
 // TODO: this is a mess
 // NOTE: destination buffer is lnbuf
 // extract data from src buffer, returns length extracted (to - from)
-ulong data(const gap_buf &src, ulong from, ulong to)
+uint data(const gap_buf &src, uint from, uint to)
 {
 	error_check;
 	// try some special cases where 1 copy is required
-	if (src.gpe() >= src.cpt() - 1) // gap ends at end
-		memcpy(lnbuf, src.buffer() + from, min(to - from, src.gps()));
-	else if (src.gps() == 0) // x = 0; gap at start
-		memcpy(lnbuf, src.buffer() + from + src.gpe() + 1, min(to, src.len()) - from);
+	if (src.gpe >= src.cpt() - 1) // gap ends at end
+		memcpy(lnbuf, src.buffer() + from, min(to - from, src.gps));
+	else if (src.gps == 0) // x = 0; gap at start
+		memcpy(lnbuf, src.buffer() + from + src.gpe + 1, min(to, src.len()) - from);
 	else {
-		if (from < src.gps()) {
-			memcpy(lnbuf, src.buffer() + from, min(to, src.gps()) - from);
-			if (to > src.gps())
-				memcpy(lnbuf + src.gps() - from, src.buffer() + src.gpe() + 1, to - src.gps());
+		if (from < src.gps) {
+			memcpy(lnbuf, src.buffer() + from, min(to, src.gps) - from);
+			if (to > src.gps)
+				memcpy(lnbuf + src.gps - from, src.buffer() + src.gpe + 1, to - src.gps);
 		} else
 			memcpy(lnbuf, src.buffer() + from + gaplen(src), to - from);
 	}
@@ -132,23 +149,24 @@ ulong data(const gap_buf &src, ulong from, ulong to)
 }
 
 // returns character at pos keeping in mind the gap
-char at(const gap_buf &src, ulong pos)
+char at(const gap_buf &src, uint pos)
 {
-	if (pos >= src.gps())
+	if (pos >= src.gps)
 		pos += gaplen(src);
 	return src[pos];
 }
 
 // to iterate in range [from, to) over the gap buffer on positions containg actual data, 2 loops may be needed to skip the gap
-void prepare_iteration(const gap_buf &src, ulong from, ulong to, ulong &st1, ulong &end1, ulong &st2, ulong &end2)
+void prepare_iteration(const gap_buf *src, uint from, uint to, uint &st1, uint &end1, uint &st2, uint &end2)
 {
 	st1 = from; end1 = to; st2 = end2 = 0;
-	if (from >= src.gps()) {
-		st1 = gaplen(src) + from;
-		end1 = gaplen(src) + to;
-	} else if (from < src.gps() && to > src.gps()) {
-		end1 = src.gps();
-		st2 = src.gpe() + 1;
-		end2 = gaplen(src) + to - from + 1 - src.gps(); // remainder
+	const uint t_gpe = src->gpe + 1;
+	if (from >= src->gps) { // range is after gap; 1 iteration needed
+		st1 = t_gpe + from;
+		end1 = t_gpe + to;
+	} else { // range starts before gap and ends after; 2 iterations needed
+		end1 = src->gps;
+		st2 = t_gpe;
+		end2 = t_gpe + to - from - 1;
 	}
 }

--- a/ds/headers/dynarray.h
+++ b/ds/headers/dynarray.h
@@ -1,0 +1,27 @@
+#include "../../headers/headers.h"
+
+// a vector<uint> is 24 bytes, this is just 8
+struct dynarray {
+	uint *array;
+
+	void set_len(uint n) { (*(array - 1)) = n; }
+	void incr_len() { (*(array - 1))++; }
+	uint len() { return *(array - 1); }
+	uint cpt() { return __bit_ceil(len()); }
+
+	dynarray() {
+		// cannot be more as __bit_ceil(0) == 1
+		array = (uint*)malloc(2 * sizeof(uint));
+		array[0] = 0;
+		array++;
+	}
+
+	void append(uint elem) {
+		uint length = len();
+		uint capacity = cpt();
+		if (length >= capacity)
+			array = (uint*)realloc(array - 1, capacity * 2 + 1) + 1;
+		array[length] = elem;
+		incr_len();
+	}
+};

--- a/ds/headers/gapbuffer.h
+++ b/ds/headers/gapbuffer.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "../../headers/headers.h"
 
-extern long ofx; // offset in x-axis
+extern long ofx; // offset in x-axis = bytes - dchars
 extern char *lnbuf; // temporary buffer for output of data()
 extern uint lnbf_cpt; // lnbuf capacity
 
@@ -46,4 +46,4 @@ void apnd_s(gap_buf &a, const char *str); // append null-terminated string
 void eras(gap_buf &a); // erase the character at current cursor position
 uint data(const gap_buf &src, uint from, uint to); // copy buffer with range to lnbuf
 char at(const gap_buf &src, uint pos); // return character at position calculating the gap
-void prepare_iteration(const gap_buf &src, uint from, uint to, uint &st1, uint &end1, uint &st2, uint &end2);
+void prepare_iteration(const gap_buf *src, uint from, uint to, uint &st1, uint &end1, uint &st2, uint &end2);

--- a/ds/headers/gapbuffer.h
+++ b/ds/headers/gapbuffer.h
@@ -6,64 +6,44 @@ extern char *lnbuf; // temporary buffer for output of data()
 extern uint lnbf_cpt; // lnbuf capacity
 
 #define array_size 8
-#define gaplen(a) ((a).gpe() - (a).gps() + 1ul)
-#define ingap(a, pos) (((pos) >= (a).gps() && (pos) <= (a).gpe()) ? true : false)
+#define gaplen(a) ((a).gpe - (a).gps + 1u)
+#define ingap(a, pos) (((pos) >= (a).gps && (pos) <= (a).gpe) ? true : false)
 #define mveras(a, pos) (mv_curs(a, pos), eras(a))
 
-inline ulong pow2(ulong n) { return 1ul << n; }
-inline uint log2(ulong n) { return 63u - __builtin_clzl(n); }
-inline ulong min(ulong a, ulong b) { return a < b ? a : b; }
-inline ulong max(ulong a, ulong b) { return a > b ? a : b; }
+inline uint pow2(uint n) { return 1u << n; }
+inline uint log2(uint n) { return 31u - __builtin_clz(n); }
+inline uint min(uint a, uint b) { return a < b ? a : b; }
+inline uint max(uint a, uint b) { return a > b ? a : b; }
 
 // pointer can also be 44 bits (3 for 8-aligned + 1 for userspace)
-const ulong PTR_MASK = 0xFFFFFFFFFFFF;	// 48-bits, = 2^48 - 1
-const ulong GPx_MASK = 0x7FFFFFFFF;	// 35-bits, = 2^35 - 1
-const ulong LOW_MASK = 0xFFFF;		// 16-bits \ 26 + 19 = 35
-const ulong HIGH_MASK = 0x7FFFF;	// 19-bits /
-const ulong CPT_MASK = 0x3F;		// 6-bits,  = 2^6  - 1
+const ulong PTR_MASK = (1ul << 48) - 1;
 
-/* bit packing in mem:
- * 0-47: pointer	48-bit	when expanded to 56-bits: see line 18,30
- * 48-63,0-19: gap start 35-bit	max value = 32 GiB
- * 20-54: gap end	35-bit	
- * 55-61: capacity	6-bit	2^cpt => max value = 2^(2^6) = 2^64 - 1*/
 struct gap_buf {
-	ulong lo;
-	ulong hi;
+	uintptr_t ptr;
+	uint gps;
+	uint gpe;
 
-	char *buffer() const { return (char*)(lo & PTR_MASK); } // in userspace bit 47 = 0
-	char &operator[](ulong pos) const { return ((char*)(lo & PTR_MASK))[pos]; }
-	ulong gps() const { return ((hi & HIGH_MASK) << 16) | (lo >> 48); } // 0-based
-	ulong gpe() const { return (hi >> 20) & GPx_MASK; } // 0-based
-	ulong cpt() const { return pow2((hi >> 55) & CPT_MASK); } // always power of 2, 1-based
-	ulong len() const { return cpt() - gaplen(*this); } // indirectly calculated, 1-based
+	char *buffer() const { return (char*)(ptr & PTR_MASK); } // in userspace bit 47 = 0
+	char &operator[](uint pos) const { return ((char*)(ptr & PTR_MASK))[pos]; }
+	uint cpt() const { uchar x = ptr >> 56; return (x > 29) ? (x * 0x1000000) : (1u << x); }
+	uint len() const { return cpt() - gaplen(*this); } // indirectly calculated, 1-based
 
 	// zero all bits outside of mask and then apply those in the mask
-	void set_buf(char *buf) { lo = (lo & ~PTR_MASK) | ((ulong)buf); }
-	void set_gps(ulong st) { lo = (lo & ~(GPx_MASK << 48)) | (st << 48); 
-				hi = (hi & ~HIGH_MASK) | (st >> 16); }
-	void set_gpe(ulong en) { hi = (hi & ~(GPx_MASK << 20)) | (en << 20); }
-	// capacity is always power of 2, only the exponent is stored
-	void set_cpt(ulong cpt) { hi = (hi & ~(CPT_MASK << 55)) | ((ulong)log2(cpt) << 55); }
-
-	gap_buf() {
-		lo = hi = 0;
-		set_cpt(array_size);
-		set_gpe(array_size - 1);
-		char *buf = (char*)malloc(array_size);
-		set_buf(buf);
-	}
+	void set_buf(char *buf) { ptr = (ptr & ~PTR_MASK) | (ulong)buf; }
+	void incr_cpt() { ptr += 0x100000000000000; }
+	void set_cpt(ulong n) { ptr = (ptr & PTR_MASK) | (n << 56u); } // from 0-255
 };
 
 void init(gap_buf &a); // initialize the gap buffer (should already be called by constructor)
-void resize(gap_buf &a, ulong size); // resize the buffer
-void mv_curs(gap_buf &a, ulong pos); // move the cursor to position
+void resize2fit(gap_buf &a, uint sz); // resize the buffer to be >= than specified size
+void resize_up(gap_buf &a); // increase 
+void mv_curs(gap_buf &a, uint pos); // move the cursor to position
 void insert_c(gap_buf &a, char ch); // insert character at cursor position
-void insert_s(gap_buf &a, const char *str, ulong len); // insert string with given length at cursor pos
+void insert_s(gap_buf &a, const char *str, uint len); // insert string with given length at cursor pos
 void apnd_c(gap_buf &a, char ch); // append character
-void apnd_s(gap_buf &a, const char *str, ulong size); // append string with given size
+void apnd_s(gap_buf &a, const char *str, uint size); // append string with given size
 void apnd_s(gap_buf &a, const char *str); // append null-terminated string
 void eras(gap_buf &a); // erase the character at current cursor position
-ulong data(const gap_buf &src, ulong from, ulong to); // copy buffer with range to lnbuf
-char at(const gap_buf &src, ulong pos); // return character at position calculating the gap
-void prepare_iteration(const gap_buf &src, ulong from, ulong to, ulong &st1, ulong &end1, ulong &st2, ulong &end2);
+uint data(const gap_buf &src, uint from, uint to); // copy buffer with range to lnbuf
+char at(const gap_buf &src, uint pos); // return character at position calculating the gap
+void prepare_iteration(const gap_buf &src, uint from, uint to, uint &st1, uint &end1, uint &st2, uint &end2);

--- a/ds/headers/gapbuffer.h
+++ b/ds/headers/gapbuffer.h
@@ -19,7 +19,7 @@ inline uint max(uint a, uint b) { return a > b ? a : b; }
 const ulong PTR_MASK = (1ul << 48) - 1;
 
 struct gap_buf {
-	uintptr_t ptr;
+	uintptr_t ptr; // TODO: take advantage of ARM TBI / Intel LAM
 	uint gps;
 	uint gpe;
 

--- a/ds/headers/gapbuffer.h
+++ b/ds/headers/gapbuffer.h
@@ -53,10 +53,6 @@ struct gap_buf {
 		char *buf = (char*)malloc(array_size);
 		set_buf(buf);
 	}
-	~gap_buf() {
-		free(buffer());
-		lo = hi = 0;
-	}
 };
 
 void init(gap_buf &a); // initialize the gap buffer (should already be called by constructor)

--- a/ds/headers/gapbuffer.h
+++ b/ds/headers/gapbuffer.h
@@ -62,8 +62,8 @@ struct gap_buf {
 void init(gap_buf &a); // initialize the gap buffer (should already be called by constructor)
 void resize(gap_buf &a, ulong size); // resize the buffer
 void mv_curs(gap_buf &a, ulong pos); // move the cursor to position
-void insert_c(gap_buf &a, ulong pos, char ch); // insert character at position
-void insert_s(gap_buf &a, ulong pos, const char *str, ulong len); // insert string with given length at pos
+void insert_c(gap_buf &a, char ch); // insert character at cursor position
+void insert_s(gap_buf &a, const char *str, ulong len); // insert string with given length at cursor pos
 void apnd_c(gap_buf &a, char ch); // append character
 void apnd_s(gap_buf &a, const char *str, ulong size); // append string with given size
 void apnd_s(gap_buf &a, const char *str); // append null-terminated string

--- a/ds/headers/merged_unrolled-list.h
+++ b/ds/headers/merged_unrolled-list.h
@@ -35,10 +35,10 @@ typedef struct iter {
 	uint relative_pos; // pos in the chunk
 	chunk *parent() const { return (chunk*)(orig); } // force-casting
 	// proxy functions to emulate being a standalone gap buffer
-	uint len() const { return parent()->len[relative_pos]; }
-	uint gps() const { return orig->gps() - offset; }
-	uint gpe() const { return orig->gpe() - offset; }
-	uint cpt() const { return len() + gpe() - gps(); }
+	ulong len() const { return parent()->len[relative_pos]; }
+	ulong gps() const { return orig->gps() - offset; }
+	ulong gpe() const { return orig->gpe() - offset; }
+	ulong cpt() const { return len() + gpe() - gps(); }
 	void set_gps(uint n) { orig->set_gps(n + offset); }
 	void set_gpe(uint n) { orig->set_gpe(n + offset); }
 	char *buffer() { return orig->buffer() + offset; }

--- a/ds/headers/merged_unrolled-list.h
+++ b/ds/headers/merged_unrolled-list.h
@@ -56,3 +56,9 @@ chunk *create_chunk();
 void goto_last_line(chunk *a);
 void append_len(chunk *a, uint len);
 void point2chunk(iter *it, chunk *a);
+
+extern llist text;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+inline void point2begin(iter *it) { *it = {.orig = &text.head->next->merged_lines}; }
+#pragma GCC diagnostic pop

--- a/ds/headers/merged_unrolled-list.h
+++ b/ds/headers/merged_unrolled-list.h
@@ -35,12 +35,12 @@ typedef struct iter {
 	uint relative_pos; // pos in the chunk
 	chunk *parent() const { return (chunk*)(orig); } // force-casting
 	// proxy functions to emulate being a standalone gap buffer
-	ulong len() const { return parent()->len[relative_pos]; }
-	ulong gps() const { return orig->gps() - offset; }
-	ulong gpe() const { return orig->gpe() - offset; }
-	ulong cpt() const { return len() + gpe() - gps(); }
-	void set_gps(uint n) { orig->set_gps(n + offset); }
-	void set_gpe(uint n) { orig->set_gpe(n + offset); }
+	uint len() const { return parent()->len[relative_pos]; }
+	uint gps() const { return orig->gps - offset; }
+	uint gpe() const { return orig->gpe - offset; }
+	uint cpt() const { return len() + orig->gpe - orig->gps; }
+	void set_gps(uint n) { orig->gps = n + offset; }
+	void set_gpe(uint n) { orig->gpe = n + offset; }
 	char *buffer() { return orig->buffer() + offset; }
 } iter;
 

--- a/ds/headers/merged_unrolled-list.h
+++ b/ds/headers/merged_unrolled-list.h
@@ -1,0 +1,58 @@
+#include "gapbuffer.h"
+
+/* small lines are merged if they sum < 256 B (to reduce size of len array)
+ * 256 to keep the array 1 byte per line (overhead ratio always <2 (or <1.7 for lines >1B))
+ * this limit could be increased if it can be guaranteed that no merged line is > 256 */
+#define MAX_CHUNK_SIZE 256
+#define connect(a, b) {(a)->next = (b); (b)->prev = (a);}
+
+// small lines are merged to reduce memory overhead
+typedef struct chunk {
+	gap_buf merged_lines;
+	struct chunk *prev;
+	struct chunk *next;
+	// should be unallocated unless there are 2 lines merged
+	unsigned char *len; // array of lengths of each merged line
+	uint num_lines; // count of lines in this chunk
+	unsigned char len_cpt; // capacity of len array
+	// 3-bytes padding (45 / 48 bytes)
+} chunk;
+/* Notes:
+ * head != tail, head and tail are imaginary nodes.
+ * 
+ */
+typedef struct llist {
+	uint nodes; // count of actual nodes allocated
+	uint lines; // count of lines (nodes + merged)
+	chunk *head; // imaginary node before first usable node
+	chunk *tail; // imaginary node after last usable node
+} llist;
+
+typedef struct iter {
+	gap_buf *orig;
+	uint offset; // offset of start of this line to 0
+	uint global_pos; // position in the list
+	uint relative_pos; // pos in the chunk
+	chunk *parent() const { return (chunk*)(orig); } // force-casting
+	// proxy functions to emulate being a standalone gap buffer
+	uint len() const { return parent()->len[relative_pos]; }
+	uint gps() const { return orig->gps() - offset; }
+	uint gpe() const { return orig->gpe() - offset; }
+	uint cpt() const { return len() + gpe() - gps(); }
+	void set_gps(uint n) { orig->set_gps(n + offset); }
+	void set_gpe(uint n) { orig->set_gpe(n + offset); }
+	char *buffer() { return orig->buffer() + offset; }
+} iter;
+
+
+void line_offset(iter *it, uint n);
+void iterate_bw(iter *it, uint dist); // backward
+void iterate_fw(iter *it, uint dist); // forward
+void rm_mline(chunk *ch, uint pos, iter *it);
+void split_mline(llist *list, chunk *cur_chunk);
+void merge_lines(llist *list, iter *a, iter *b);
+void insert_chunk(llist *list, chunk *before, chunk *new_chunk);
+chunk *create_chunk();
+void goto_last_line(chunk *a);
+void append_len(chunk *a, uint len);
+void point2chunk(iter *it, chunk *a);

--- a/ds/merged_unrolled-list.cpp
+++ b/ds/merged_unrolled-list.cpp
@@ -1,0 +1,176 @@
+#include "headers/merged_unrolled-list.h"
+#include <ncurses.h>
+
+// point iterator to chunk (global_pos not updated)
+void point2chunk(iter *it, chunk *a)
+{
+	it->orig = &a->merged_lines;
+	it->relative_pos = it->offset = 0;
+}
+
+void append_len(chunk *a, uint len)
+{
+	if (a->len_cpt < a->num_lines + 1) {
+		a->len_cpt = (1 + a->len_cpt) * 2;
+		a->len = (uchar*)realloc(a->len, a->len_cpt);
+	}
+	a->len[a->num_lines] = len;
+	a->num_lines++;
+}
+
+// get offset
+void line_offset(iter *it, uint n)
+{
+	chunk *a = it->parent();
+	uint count = 0, i = it->relative_pos;
+	for (; i < it->relative_pos + n; ++i)
+		count += a->len[i];
+	it->offset += count;
+	it->relative_pos = i;
+}
+
+// increase iterator backwards by dist lines
+void iterate_bw(iter *it, uint dist)
+{
+	chunk *a = it->parent();
+	it->global_pos -= dist;
+	while (dist > it->relative_pos) {
+		dist -= it->relative_pos;
+		a = a->prev;
+		point2chunk(it, a);
+		it->relative_pos = a->num_lines;
+	}
+	uint tmp = it->relative_pos;
+	it->relative_pos = it->offset = 0;
+	line_offset(it, tmp - dist);
+	//mv_curs(*it->orig, it->offset);
+}
+
+// increase iterator forwards by dist lines
+void iterate_fw(iter *it, uint dist)
+{
+	chunk *a = it->parent();
+	it->global_pos += dist;
+	while (dist + it->relative_pos >= a->num_lines) { // TODO: optimize
+		dist -= (a->num_lines - it->relative_pos);
+		a = a->next;
+		point2chunk(it, a);
+	}
+	line_offset(it, dist);
+	//mv_curs(*it->orig, it->offset);
+}
+
+// remove a line from a chunk
+void rm_mline(chunk *ch, uint pos, iter *it) { // FIXME: broken
+	if (ch->num_lines == 1) {
+		connect(ch->prev, ch->next);
+		free(ch);
+	} else {
+		if (it)
+			it->orig->set_gpe(it->offset + it->len());
+		memmove(&ch->len[pos], &ch->len[pos + 1], ch->num_lines - pos - 1);
+		ch->num_lines--;
+	}
+}
+
+// moves actual cursor to last line
+void goto_last_mline(chunk *a) { mv_curs(a->merged_lines, a->merged_lines.len() - a->len[a->num_lines - 1]); }
+
+// TODO: it may be faster to split the first of merged lines
+// merged line has grown too much; split last line by moving it to next node (or create new to fit)
+void split_mline(llist *list, chunk *a)
+{
+	uint last_length = a->len[a->num_lines - 1];
+	
+	chunk *next_chunk; // may be newly allocated
+	// create new chunk if last line doesn't fit in next chunk
+	if (a->next == list->tail || a->next->merged_lines.len() + last_length > MAX_CHUNK_SIZE) {
+		next_chunk = create_chunk();
+		insert_chunk(list, a, next_chunk);
+	} else { // shift all lengths of next chunk by one to put this length in pos 0
+		next_chunk = a->next;
+		memmove(&next_chunk->len[1], &next_chunk->len[0], next_chunk->num_lines);
+	}
+	a->num_lines--;
+	apnd_s(next_chunk->merged_lines, a->merged_lines.buffer() + a->merged_lines.len() - last_length, last_length);
+	append_len(next_chunk, last_length);
+	// delete last line
+	a->merged_lines.set_gpe(a->merged_lines.cpt() - 1);
+}
+
+// merge b into a
+void mergeba(iter *a, iter *b)
+{
+	chunk *a_ch = a->parent(), *b_ch = b->parent();
+	insert_s(a_ch->merged_lines, b_ch->merged_lines.buffer(), b->len() - 1);
+	a_ch->len[a->relative_pos] = a->len() + b->len() - 1;
+	rm_mline(b_ch, b->relative_pos, nullptr);
+}
+
+// TODO: this is a mess
+// merge a and b, b is invalidated
+void merge_lines(llist *list, iter *a, iter *b)
+{
+	chunk *a_ch = a->parent(), *b_ch = b->parent();
+	if (a_ch == b_ch) {
+		eras(a_ch->merged_lines);
+		uint rel_pos = a->relative_pos;
+		a_ch->len[rel_pos + 1] += a_ch->len[rel_pos] - 1;
+		memmove(&a_ch->len[rel_pos], &a_ch->len[rel_pos + 1], a_ch->num_lines - rel_pos);
+		a_ch->num_lines--;
+	} else { // need to move at least one line to another chunk
+		bool use_a = a_ch->merged_lines.len() + b->len() < MAX_CHUNK_SIZE || a_ch->num_lines == 0;
+		bool use_b = b_ch->merged_lines.len() + a->len() < MAX_CHUNK_SIZE || b_ch->num_lines == 0;
+		if (use_a && use_b) { // merge small into large
+			if (a_ch->merged_lines.len() < b_ch->merged_lines.len())
+				use_b = false;
+			else
+				use_a = false;
+		}
+		if (use_a)
+			mergeba(b, a);
+		else if (use_b)
+			mergeba(a, b);
+		else {
+			// 3rd case: none fits; create new chunk
+			chunk *new_chunk = create_chunk();
+			// combine a and b's lines (remove a's last char as a newline)
+			apnd_s(new_chunk->merged_lines, a_ch->merged_lines.buffer() + a->offset, a->len() - 1);
+			rm_mline(a_ch, a->relative_pos, nullptr);
+			apnd_s(new_chunk->merged_lines, b_ch->merged_lines.buffer() + b->offset, b->len());
+			rm_mline(b_ch, b->relative_pos, nullptr);
+			
+			append_len(new_chunk, a->len() + b->len() - 1);
+			insert_chunk(list, a_ch, new_chunk);
+			point2chunk(a, a_ch);
+		}
+	}
+}
+
+// insert new_line after before
+/*void insert_line(llist *list, iter *before, gap_buf *new_line)
+{
+	if (before->orig->len() + new_line->len() < 256) {
+		insert_s(*before->orig, new_line->buffer(), new_line->len());
+		chunk *ch = before->parent();
+		uint pos = before->relative_pos + 1;
+		memmove(&ch->len[pos], &ch->len[pos - 1], ch->num_lines - pos - 1);
+	} else if ()
+}*/
+
+// insert new before
+void insert_chunk(llist *list, chunk *before, chunk *new_chunk)
+{
+	connect(new_chunk, before->next);
+	connect(before, new_chunk);
+	list->nodes++;
+}
+
+chunk *create_chunk()
+{
+	chunk *new_chunk = (chunk*)malloc(sizeof(chunk));
+	new_chunk->num_lines = new_chunk->len_cpt = 0;
+	new_chunk->len = nullptr;
+	init(new_chunk->merged_lines);
+	return new_chunk;
+}

--- a/ds/merged_unrolled-list.cpp
+++ b/ds/merged_unrolled-list.cpp
@@ -137,8 +137,7 @@ void merge_lines(llist *list, iter *a, iter *b)
 			mergeba(b, a);
 		else if (use_b)
 			mergeba(a, b);
-		else {
-			// 3rd case: none fits; create new chunk
+		else { // 3rd case: none fits; create new chunk
 			chunk *new_chunk = create_chunk();
 			// combine a and b's lines (remove a's last char as a newline)
 			apnd_s(new_chunk->merged_lines, a_ch->merged_lines.buffer() + a->offset, a->len() - 1);
@@ -152,17 +151,6 @@ void merge_lines(llist *list, iter *a, iter *b)
 		}
 	}
 }
-
-// insert new_line after before
-/*void insert_line(llist *list, iter *before, gap_buf *new_line)
-{
-	if (before->orig->len() + new_line->len() < 256) {
-		insert_s(*before->orig, new_line->buffer(), new_line->len());
-		chunk *ch = before->parent();
-		uint pos = before->relative_pos + 1;
-		memmove(&ch->len[pos], &ch->len[pos - 1], ch->num_lines - pos - 1);
-	} else if ()
-}*/
 
 // insert new before
 void insert_chunk(llist *list, chunk *before, chunk *new_chunk)

--- a/ds/merged_unrolled-list.cpp
+++ b/ds/merged_unrolled-list.cpp
@@ -73,7 +73,7 @@ void rm_mline(chunk *ch, uint pos, iter *it) { // FIXME: broken
 		free(ch);
 	} else {
 		if (it)
-			it->orig->set_gpe(it->offset + it->len());
+			it->orig->gpe = it->offset + it->len();
 		memmove(&ch->len[pos], &ch->len[pos + 1], ch->num_lines - pos - 1);
 		ch->num_lines--;
 	}
@@ -101,7 +101,7 @@ void split_mline(llist *list, chunk *a)
 	apnd_s(next_chunk->merged_lines, a->merged_lines.buffer() + a->merged_lines.len() - last_length, last_length);
 	append_len(next_chunk, last_length);
 	// delete last line
-	a->merged_lines.set_gpe(a->merged_lines.cpt() - 1);
+	a->merged_lines.gpe = a->merged_lines.cpt() - 1;
 }
 
 // merge b into a

--- a/ds/merged_unrolled-list.cpp
+++ b/ds/merged_unrolled-list.cpp
@@ -11,10 +11,11 @@ void point2chunk(iter *it, chunk *a)
 void append_len(chunk *a, uint len)
 {
 	if (a->len_cpt < a->num_lines + 1) {
-		a->len_cpt = (1 + a->len_cpt) * 2;
-		a->len = (uchar*)realloc(a->len, a->len_cpt);
+		a->len = (uchar*)realloc(a->len, a->len_cpt * 2);
+		memset(a->len + a->len_cpt, 0, a->len_cpt);
+		a->len_cpt = a->len_cpt * 2;
 	}
-	a->len[a->num_lines] = len;
+	a->len[a->num_lines - 1] += len;
 	a->num_lines++;
 }
 
@@ -59,7 +60,7 @@ void iterate_fw(iter *it, uint dist)
 		do {
 			dist -= a->num_lines;
 			a = a->next;
-		} while (dist >= a->num_lines);
+		} while (dist > a->num_lines);
 		point2chunk(it, a);
 	}
 	line_offset(it, dist);
@@ -86,7 +87,7 @@ void goto_last_mline(chunk *a) { mv_curs(a->merged_lines, a->merged_lines.len() 
 void split_mline(llist *list, chunk *a)
 {
 	uint last_length = a->len[a->num_lines - 1];
-	
+
 	chunk *next_chunk; // may be newly allocated
 	// create new chunk if last line doesn't fit in next chunk
 	if (a->next == list->tail || a->next->merged_lines.len() + last_length > MAX_CHUNK_SIZE) {
@@ -144,7 +145,7 @@ void merge_lines(llist *list, iter *a, iter *b)
 			rm_mline(a_ch, a->relative_pos, nullptr);
 			apnd_s(new_chunk->merged_lines, b_ch->merged_lines.buffer() + b->offset, b->len());
 			rm_mline(b_ch, b->relative_pos, nullptr);
-			
+
 			append_len(new_chunk, a->len() + b->len() - 1);
 			insert_chunk(list, a_ch, new_chunk);
 			point2chunk(a, a_ch);
@@ -174,8 +175,9 @@ void insert_chunk(llist *list, chunk *before, chunk *new_chunk)
 chunk *create_chunk()
 {
 	chunk *new_chunk = (chunk*)malloc(sizeof(chunk));
-	new_chunk->num_lines = new_chunk->len_cpt = 0;
-	new_chunk->len = nullptr;
+	new_chunk->num_lines = 1;
+	new_chunk->len_cpt = 8;
+	new_chunk->len = (uchar*)calloc(8, 1);
 	init(new_chunk->merged_lines);
 	return new_chunk;
 }

--- a/ds/merged_unrolled-list.cpp
+++ b/ds/merged_unrolled-list.cpp
@@ -34,16 +34,19 @@ void iterate_bw(iter *it, uint dist)
 {
 	chunk *a = it->parent();
 	it->global_pos -= dist;
-	while (dist > it->relative_pos) {
+	if (dist > it->relative_pos) {
 		dist -= it->relative_pos;
 		a = a->prev;
-		point2chunk(it, a);
+		while (dist > a->num_lines) {
+			dist -= a->num_lines;
+			a = a->prev;
+		}
+		it->orig = &a->merged_lines;
 		it->relative_pos = a->num_lines;
 	}
 	uint tmp = it->relative_pos;
 	it->relative_pos = it->offset = 0;
 	line_offset(it, tmp - dist);
-	//mv_curs(*it->orig, it->offset);
 }
 
 // increase iterator forwards by dist lines
@@ -51,13 +54,15 @@ void iterate_fw(iter *it, uint dist)
 {
 	chunk *a = it->parent();
 	it->global_pos += dist;
-	while (dist + it->relative_pos >= a->num_lines) { // TODO: optimize
-		dist -= (a->num_lines - it->relative_pos);
-		a = a->next;
+	if (dist + it->relative_pos >= a->num_lines) { // go to next chunk
+		dist += it->relative_pos;
+		do {
+			dist -= a->num_lines;
+			a = a->next;
+		} while (dist >= a->num_lines);
 		point2chunk(it, a);
 	}
 	line_offset(it, dist);
-	//mv_curs(*it->orig, it->offset);
 }
 
 // remove a line from a chunk

--- a/ds/merged_unrolled-list.cpp
+++ b/ds/merged_unrolled-list.cpp
@@ -1,9 +1,9 @@
 #include "headers/merged_unrolled-list.h"
-#include <ncurses.h>
 
 // point iterator to chunk (global_pos not updated)
 void point2chunk(iter *it, chunk *a)
 {
+	// *it = {.orig = x} not used as it zeroes global_pos
 	it->orig = &a->merged_lines;
 	it->relative_pos = it->offset = 0;
 }

--- a/headers/headers.h
+++ b/headers/headers.h
@@ -3,7 +3,7 @@
 #include <string.h>
 #include <locale.h>	// for setting locale
 #include <vector>
-#include <thread>
+#include <pthread.h>
 #include <bit>	// for __bit_ceil (cntlz)
 #include <signal.h> // for pause in command suspend
 #include <sys/mman.h>

--- a/headers/headers.h
+++ b/headers/headers.h
@@ -2,11 +2,13 @@
 #include <stdlib.h>
 #include <string.h>
 #include <locale.h>	// for setting locale
-#include <list>
 #include <vector>
 #include <thread>
 #include <bit>	// for __bit_ceil (cntlz)
 #include <signal.h> // for pause in command suspend
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <fcntl.h>
 typedef uint64_t ulong;
 typedef uint32_t uint;
 typedef uint16_t ushort;

--- a/headers/headers.h
+++ b/headers/headers.h
@@ -11,4 +11,3 @@
 #include <fcntl.h>
 typedef uint8_t uchar;
 using namespace std;
-void log(const char *str, ...);

--- a/headers/headers.h
+++ b/headers/headers.h
@@ -9,8 +9,6 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-typedef uint64_t ulong;
-typedef uint32_t uint;
-typedef uint16_t ushort;
 typedef uint8_t uchar;
 using namespace std;
+void log(const char *str, ...);

--- a/headers/main.h
+++ b/headers/main.h
@@ -1,7 +1,7 @@
 #pragma once
-#include "../utils/headers/gapbuffer.h"
-extern list<gap_buf> text;
-extern list<gap_buf>::iterator it;
+#include "../ds/headers/merged_unrolled-list.h"
+extern llist text;
+extern iter it;
 
 // displayed characters of previous cut (or cut|slice of line)
 #define dchar first
@@ -20,4 +20,3 @@ extern uint maxy, maxx; // to store the maximum rows and columns
 extern long ofy; // offset in y axis of text and screen, x axis is in gapbuffer
 extern ulong ry, rx; // x, y positions in buffer/list
 extern char *filename; // name of open file, if none, it isn't malloc'ed 
-extern ulong curnum; // total lines counter

--- a/headers/main.h
+++ b/headers/main.h
@@ -18,5 +18,5 @@ extern uint flag; // displayed x processed by offset funcs in size.cpp
 extern uint y, x;
 extern uint maxy, maxx; // to store the maximum rows and columns
 extern long ofy; // offset in y axis of text and screen, x axis is in gapbuffer
-extern ulong ry, rx; // x, y positions in buffer/list
+extern uint ry, rx; // x, y positions in buffer/list
 extern char *filename; // name of open file, if none, it isn't malloc'ed 

--- a/main.cpp
+++ b/main.cpp
@@ -9,7 +9,7 @@ WINDOW *header_win, *ln_win, *text_win;
 wchar_t s[4];
 char s2[4], *filename;
 cchar_t mark;
-ulong ry, rx;
+uint ry, rx;
 uint y, x, maxy, maxx, flag;
 long ofy;
 
@@ -177,7 +177,7 @@ init:
 			if (x > 0) {
 				eras(*it.orig);
 				it.parent()->len[it.relative_pos]--;
-				if (it.orig->buffer()[it.orig->gps()] == '\t') { // deleted a tab
+				if (it.orig->buffer()[it.orig->gps] == '\t') { // deleted a tab
 					ofx += prevdchar();
 					x = getcurx(text_win);
 					mvprint_line(y, 0, &it, 0, 0);

--- a/main.cpp
+++ b/main.cpp
@@ -241,10 +241,13 @@ init:
 				print_text(y);
 				wmove(text_win, y, 0);
 			} else { // clear line buffer
-				rm_mline(it.parent(), it.relative_pos, &it);
+				it.orig->gps = 0;
+				it.orig->gpe = it.orig->cpt() - 1;
+				it.parent()->len[0] = 1;
+				it.parent()->num_lines = 1;
 				clearline;
 			}
-			break;//*/
+			break;
 
 		case ENTER:
 			enter();

--- a/main.cpp
+++ b/main.cpp
@@ -1,15 +1,15 @@
 #include "utils/headers/key_func.h"
 #include "headers/keybindings.h"
 
-list<gap_buf> text(2);
-list<gap_buf>::iterator it;
+llist text;
+iter it;
 vector<pair<uint, uint>> cut;
 vector<bool> overflows;
 WINDOW *header_win, *ln_win, *text_win;
 wchar_t s[4];
 char s2[4], *filename;
 cchar_t mark;
-ulong ry, rx, curnum;
+ulong ry, rx;
 uint y, x, maxy, maxx, flag;
 long ofy;
 
@@ -50,22 +50,26 @@ int main(int argc, char *argv[])
 		"help		List commands");
 		return 0;
 	}
-	it = text.begin();
-
+	text.head = create_chunk();
+	text.tail = create_chunk();
+	chunk *new_chunk_tmp = create_chunk();
+	connect(text.head, new_chunk_tmp); // insert without updating size
+	connect(new_chunk_tmp, text.tail);
+	point2chunk(&it, text.head->next);
 read:
 	if (argc > 1) {
 		filename = (char*)malloc(sizeof(char) * 128);
 		strcpy(filename, argv[1]);
-		FILE *fi = fopen(filename, "r");
+		int fd = open(filename, O_RDONLY);
 #ifdef HIGHLIGHT
 		eligible = isc(argv[1]); // syntax highlighting
 #endif
-		if (fi == NULL) {
+		if (fd == -1) {
 			print2header("New file", 1);
 			goto init;
 		}
-		read_fread(fi);
-		fclose(fi);
+		read_file(fd);
+		close(fd);
 	}
 init:
 	init_curses();
@@ -82,20 +86,25 @@ init:
 	wnoutrefresh(header_win);
 	overflows.resize(maxy, 0);
 	// all functions think there is a newline at EOL, emulate it
-	if (it->buffer()[it->len()] != '\n')
-		apnd_c(*it, 0);
+	// if (it.orig->buffer()[it.orig->len()] != '\n') {
+		// apnd_c(*it.orig, 0);
+		// it.parent()->len[it.parent()->num_lines - 1]++;
+	// }
+
 	print_text(0);
 //loop:
 	wmove(text_win, 0, 0);
-	it = text.begin();
+	point2chunk(&it, text.head->next);
+	it.relative_pos = it.global_pos = 0;
+
 	while (1) {
 		getyx(text_win, y, x);
 		ry = y + ofy;
 		// if out of bounds: move (to avoid bugs)
-		if (x > min(it->len() - 1 - ofx, maxx))
-			wmove(text_win, y, x = min(it->len() - ofx - 1, maxx));
+		if (x > min(it.len() - 1 - ofx, maxx))
+			wmove(text_win, y, x = min(it.len() - ofx - 1, maxx));
 		rx = x + ofx;
-		mv_curs(*it, rx);
+		mv_curs(*it.orig, rx + it.offset);
 
 #ifndef RELEASE
 		stats();
@@ -108,17 +117,17 @@ init:
 		wget_wch(text_win, (wint_t*)s);
 		switch (s[0]) {
 		case DOWN:
-			if (ry >= curnum) // do not scroll indefinetly
+			if (ry >= text.lines) // do not scroll indefinetly
 				break;
 			if (!cut.empty()) // revert cut
-				mvprint_line(y, 0, *it, 0, 0);
+				mvprint_line(y, 0, &it, 0, 0);
 			cut.clear();
 			ofx = 0; // invalidated
-			if (y == maxy - 1 && ry < curnum)
+			if (y == maxy - 1 && ry < text.lines)
 				scrolldown();
 			else {
-				++it;
-				ofx = calc_offset_dis(x, *it);
+				iterate_fw(&it, 1);
+				ofx = calc_offset_dis(x, 0, &it);
 				if (flag < maxx)
 					wmove(text_win, y + 1, flag);
 				else { // tab cut
@@ -131,12 +140,12 @@ init:
 
 		case UP:
 			if (!cut.empty()) // revert cut
-				mvprint_line(y, 0, *it, 0, 0);
+				mvprint_line(y, 0, &it, 0, 0);
 			if (y == 0 && ofy != 0)
 				scrollup();
 			else if (y != 0) {
-				--it;
-				ofx = calc_offset_dis(x, *it);
+				iterate_bw(&it, 1);
+				ofx = calc_offset_dis(x, 0, &it);
 				if (flag < maxx)
 					wmove(text_win, y - 1, flag);
 				else { // tab cut
@@ -166,11 +175,12 @@ init:
 
 		case BACKSPACE:
 			if (x > 0) {
-				eras(*it);
-				if (it->buffer()[it->gps()] == '\t') { // deleted a tab
+				eras(*it.orig);
+				it.parent()->len[it.relative_pos]--;
+				if (it.orig->buffer()[it.orig->gps()] == '\t') { // deleted a tab
 					ofx += prevdchar();
 					x = getcurx(text_win);
-					mvprint_line(y, 0, *it, 0, 0);
+					mvprint_line(y, 0, &it, 0, 0);
 					wclrtoeol(text_win);
 				} else {
 					mvwdelch(text_win, y, --x);
@@ -178,75 +188,63 @@ init:
 						print_new_mark();
 				}
 				clear_attrs;
-				highlight(y, *it);
+				highlight(y, &it);
 				wmove(text_win, y, x);
 			} else if (!cut.empty()) { // delete x_-1 on cut line
-				eras(*it);
+				eras(*it.orig);
+				it.parent()->len[it.relative_pos]--;
 				left();
 			} else if (y != 0) { // x = 0 && cut.empty(); merge lines
-				list<gap_buf>::iterator curln = it;
-				--it;
-				const uint tmp = it->len() - 1;
-				mv_curs(*it, tmp); // delete \n
-				it->set_gpe(it->cpt() - 1);
-
-				data(*curln, 0, curln->len());
-				apnd_s(*it, lnbuf, curln->len()); // merge
-				text.erase(curln); // delete actual line
-				--curnum;
+				iter b = it;
+				iterate_bw(&it, 1);
+				uint tmp = it.len();
+				merge_lines(&text, &it, &b);
+				--text.lines;
 				print_text(--y);
-				wmove(text_win, y, 0);
-				mvr_scurs(tmp + 1);
+				mvr_scurs(tmp);
 			}
 			break;
 
 		case DELETE:
-			if (it->buffer()[it->gpe() + 1u] == '\n') { // similar to backspace
-				list<gap_buf>::iterator curln = it; // current line
-				curln->set_gpe(curln->cpt() - 1); // delete newline
-				++it; // next line
-				data(*it, 0, it->len());
-				apnd_s(*curln, lnbuf, it->len());
-				text.erase(it);
-				it = curln;
-				--curnum;
+			if (it.buffer()[it.gpe() + 1u] == '\n') { // similar to backspace
+				iter b = it;
+				iterate_fw(&b, 1);
+				merge_lines(&text, &it, &b);
+				--text.lines;
 				print_text(y);
 				wmove(text_win, y, x);
-			} else if (rx + 1 < it->len()) {
+			} else if (rx + 1 < it.len()) {
+				it.parent()->len[it.relative_pos]--;
 				// or mblen(it->buffer + it->gpe + 1, 3);
-				uint len = it->buffer()[it->gpe() + 1] < 0 ? 2 : 1;
-				mveras(*it, rx + len);
+				uint len = it.buffer()[it.gpe() + 1] < 0 ? 2 : 1;
+				mveras(*it.orig, rx + len);
 				ofx += len - 1;
-				if (it->buffer()[it->gps()] == '\t') {
+				if (it.buffer()[it.gps()] == '\t') {
 					wclrtoeol(text_win);
-					mvprint_line(y, x, *it, rx, 0);
+					mvprint_line(y, x, &it, rx, 0);
 				} else {
 					wdelch(text_win);
 					clear_attrs;
 					print_new_mark();
 				}
-				highlight(y, *it);
+				highlight(y, &it);
 				wmove(text_win, y, x);
 			}
 			break;
 
 		case DELLINE:
-			if (curnum > 0 && text.size() > 2) {
-				curnum--;
-				list<gap_buf>::iterator curln = it;
-				++it;
-				text.erase(curln);
+			if (text.lines > 0 && text.nodes > 2) {
+				rm_mline(it.parent(), it.relative_pos, &it);
+				text.lines--;
 				print_text(y);
 				wmove(text_win, y, 0);
 			} else { // clear line buffer
-				it->set_gps(0); it->set_gpe(it->cpt() - 2);
-				it->buffer()[it->cpt() - 1] = 0;
+				rm_mline(it.parent(), it.relative_pos, &it);
 				clearline;
 			}
-			break;
+			break;//*/
 
 		case ENTER:
-			highlight(y, *it);
 			enter();
 			break;
 
@@ -262,8 +260,8 @@ init:
 			save();
 			s2[0] = 0; // no new char has been inserted since last save
 			argc = 3;
-			if (text.size() % 2 == 1)
-				text.resize(text.size() + 1);
+			// if (text.size() % 2 == 1)
+				// text.resize(text.size() + 1);
 			break;
 
 		case 27: { // ALT or ESC
@@ -277,14 +275,14 @@ init:
 			else if (ch == SWITCH) { // switch file
 				argc = 2;
 				argv[1] = input_header("File to open: ");
-				list<gap_buf>::iterator iter;
+				/*list<gap_buf>::iterator iter;
 				uint i;
-				for (iter = text.begin(), i = 0; iter != text.end() && i <= curnum; ++iter, ++i) {
+				for (iter = text.begin(), i = 0; iter != text.end() && i <= text.size; ++iter, ++i) {
 					iter->set_gps(0);
 					iter->set_gpe(iter->cpt());
 				}
-				curnum = 0;
-				it = text.begin();
+				text.size = 0;
+				it = text.begin();*/
 				wclear(text_win);
 				goto read;
 			}
@@ -308,7 +306,7 @@ init:
 
 		case EXIT:
 			// has char been inserted, new file, allocations are multiples of 2
-			if (s2[0] != 0 || argc < 2 || text.size() % 2 == 1) {
+			if (s2[0] != 0 || argc < 2 /*|| text.nodes % 2 == 1*/) {
 				char *in = input_header("Exit and Save changes? (y/n/c) ");
 				flag = in[0]; // tmp var to free branchlessly | TODO: getch()
 				free(in);
@@ -323,8 +321,8 @@ init:
 			goto stop;
 
 		case KEY_TAB:
-			insert_c(*it, rx, '\t');
-			mvprint_line(y, x, *it, rx, 0);
+			insert_c(*it.orig, '\t');
+			mvprint_line(y, x, &it, rx, 0);
 			ofx -= 7 - x % 8;
 			wmove(text_win, y, x + 8 - x % 8);
 			break;
@@ -336,23 +334,24 @@ init:
 				cut.push_back({maxx - 1, ofx});
 				clearline;
 				ofx += maxx - 1;
-				print_line(*it, ofx, 0, y);
+				print_line(&it, ofx, 0, y);
 				wmove(text_win, y, x = 0);
 				rx = ofx;
-			} if (it->buffer()[it->gpe() + 1] == '\t') { // next character is a tab
+			} if (it.buffer()[it.gpe() + 1] == '\t') { // next character is a tab
 				waddnwstr(text_win, s, 1);
 				if (x % 8 >= 7) // filled the empty tab space; reprint tab
 					winsch(text_win, '\t');
 			} else {
 				wins_nwstr(text_win, s, 1);
 				clear_attrs;
-				highlight(y, *it);
+				highlight(y, &it);
 				wmove(text_win, y, x + 1);
 			}
 			uint len = wcstombs(s2, s, 4);
-			insert_s(*it, rx, s2, len);
+			insert_s(*it.orig, s2, len);
 			if (len > 1)
 				ofx += len - 1; // UTF-8 character
+			it.parent()->len[it.relative_pos] += len;
 			break;
 		}
 	}

--- a/main.cpp
+++ b/main.cpp
@@ -33,7 +33,6 @@ int main(int argc, char *argv[])
 		"Go to end of line:	Ctrl-E\n"
 		"Built-in terminal:	Alt-C\n"
 		"Delete line:		Ctrl-K\n"
-		"Open other file:	Alt-R\n"
 		"Previous/Next word	Shift + Left/Right arrow\n"
 		"Show debbuging info:	Alt-I (also command stats in built-in terminal)\n\n"
 		"Built-in terminal commands:\n"
@@ -56,7 +55,7 @@ int main(int argc, char *argv[])
 	connect(text.head, new_chunk_tmp); // insert without updating size
 	connect(new_chunk_tmp, text.tail);
 	point2chunk(&it, text.head->next);
-read:
+
 	if (argc > 1) {
 		filename = (char*)malloc(sizeof(char) * 128);
 		strcpy(filename, argv[1]);
@@ -85,11 +84,12 @@ init:
 	wnoutrefresh(ln_win);
 	wnoutrefresh(header_win);
 	overflows.resize(maxy, 0);
+	new_chunk_tmp = text.tail->prev;
 	// all functions think there is a newline at EOL, emulate it
-	// if (it.orig->buffer()[it.orig->len()] != '\n') {
-		// apnd_c(*it.orig, 0);
-		// it.parent()->len[it.parent()->num_lines - 1]++;
-	// }
+	if (new_chunk_tmp->merged_lines.buffer()[new_chunk_tmp->merged_lines.len() - 1] != '\n') {
+		apnd_c(*it.orig, 0);
+		new_chunk_tmp->len[new_chunk_tmp->num_lines - 1]++;
+	}
 
 	print_text(0);
 //loop:
@@ -260,8 +260,6 @@ init:
 			save();
 			s2[0] = 0; // no new char has been inserted since last save
 			argc = 3;
-			// if (text.size() % 2 == 1)
-				// text.resize(text.size() + 1);
 			break;
 
 		case 27: { // ALT or ESC
@@ -272,20 +270,6 @@ init:
 				stats();
 			else if (ch == CMD)
 				command();
-			else if (ch == SWITCH) { // switch file
-				argc = 2;
-				argv[1] = input_header("File to open: ");
-				/*list<gap_buf>::iterator iter;
-				uint i;
-				for (iter = text.begin(), i = 0; iter != text.end() && i <= text.size; ++iter, ++i) {
-					iter->set_gps(0);
-					iter->set_gpe(iter->cpt());
-				}
-				text.size = 0;
-				it = text.begin();*/
-				wclear(text_win);
-				goto read;
-			}
 			wmove(text_win, y, x);
 			break;
 		}
@@ -305,8 +289,8 @@ init:
 			break;
 
 		case EXIT:
-			// has char been inserted, new file, allocations are multiples of 2
-			if (s2[0] != 0 || argc < 2 /*|| text.nodes % 2 == 1*/) {
+			// has char been inserted, new file
+			if (s2[0] != 0 || argc < 2) {
 				char *in = input_header("Exit and Save changes? (y/n/c) ");
 				flag = in[0]; // tmp var to free branchlessly | TODO: getch()
 				free(in);

--- a/main.cpp
+++ b/main.cpp
@@ -71,6 +71,12 @@ int main(int argc, char *argv[])
 		close(fd);
 	}
 init:
+	// all functions think there is a newline at EOL, emulate it
+	if (!it.orig->len() || it.orig->buffer()[it.orig->len() - 1] != '\n') {
+		apnd_c(*it.orig, 0);
+		it.parent()->len[it.parent()->num_lines - 1]++;
+	}
+
 	init_curses();
 	getmaxyx(stdscr, maxy, maxx);
 
@@ -85,11 +91,6 @@ init:
 	wnoutrefresh(header_win);
 	overflows.resize(maxy, 0);
 	new_chunk_tmp = text.tail->prev;
-	// all functions think there is a newline at EOL, emulate it
-	if (new_chunk_tmp->merged_lines.buffer()[new_chunk_tmp->merged_lines.len() - 1] != '\n') {
-		apnd_c(*it.orig, 0);
-		new_chunk_tmp->len[new_chunk_tmp->num_lines - 1]++;
-	}
 
 	print_text(0);
 //loop:

--- a/main.cpp
+++ b/main.cpp
@@ -51,10 +51,12 @@ int main(int argc, char *argv[])
 	}
 	text.head = create_chunk();
 	text.tail = create_chunk();
+{
 	chunk *new_chunk_tmp = create_chunk();
 	connect(text.head, new_chunk_tmp); // insert without updating size
 	connect(new_chunk_tmp, text.tail);
-	point2chunk(&it, text.head->next);
+	point2begin(&it);
+}
 
 	if (argc > 1) {
 		filename = (char*)malloc(sizeof(char) * 128);
@@ -71,6 +73,7 @@ int main(int argc, char *argv[])
 		close(fd);
 	}
 init:
+	point2chunk(&it, text.tail->prev);
 	// all functions think there is a newline at EOL, emulate it
 	if (!it.orig->len() || it.orig->buffer()[it.orig->len() - 1] != '\n') {
 		apnd_c(*it.orig, 0);
@@ -90,13 +93,11 @@ init:
 	wnoutrefresh(ln_win);
 	wnoutrefresh(header_win);
 	overflows.resize(maxy, 0);
-	new_chunk_tmp = text.tail->prev;
 
 	print_text(0);
 //loop:
 	wmove(text_win, 0, 0);
-	point2chunk(&it, text.head->next);
-	it.relative_pos = it.global_pos = 0;
+	point2begin(&it);
 
 	while (1) {
 		getyx(text_win, y, x);

--- a/main.cpp
+++ b/main.cpp
@@ -123,7 +123,7 @@ init:
 				mvprint_line(y, 0, &it, 0, 0);
 			cut.clear();
 			ofx = 0; // invalidated
-			if (y == maxy - 1 && ry < text.lines)
+			if (y == maxy - 1)
 				scrolldown();
 			else {
 				iterate_fw(&it, 1);

--- a/screen/headers/highlight.h
+++ b/screen/headers/highlight.h
@@ -4,5 +4,5 @@
 
 extern bool eligible; // is syntax highlighting enabled
 bool isc(const char *str);
-void highlight(uint line, const gap_buf &buffer); // highlight line y of screen if eligible
+void highlight(uint line, const iter *i); // highlight line y of screen if eligible
 #define clear_attrs (wmove(text_win, y, 0), wchgat(text_win, maxx - 1, 0, 0, nullptr))

--- a/screen/highlight.cpp
+++ b/screen/highlight.cpp
@@ -74,7 +74,7 @@ static res_t get_category(const char *line)
 
 	if (binary_search(types, types_len, nelems(types_len), line, res, TYPE));
 	else if (binary_search(keywords, keywords_len, nelems(keywords_len), line, res, KEYWORD));
-	else if (memchr(oper, line[0], sizeof(oper))) { // binary search would require an array of the form {1,2,3..}
+	else if (memchr(oper, line[0], sizeof(oper))) { // above binary search would require an array of the form {1,2,3..}
 		res.len = 1;
 		res.type = OPER;
 	}
@@ -83,13 +83,13 @@ static res_t get_category(const char *line)
 
 static char continued; // string/comment/directive etc. continued after cut/ in next line
 // highight line
-static void apply(uint line, const gap_buf &buf)
+static void apply(uint line, const iter *cur_ln)
 {
 	if (line == 0) // there is no previous line visible
 		continued = 0;
 	wmove(text_win, line, 0);
 
-	const uint len = min(maxx - 1, bytes2dchar(buf.len(), 0, buf));
+	const uint len = min(maxx - 1, bytes2dchar(cur_ln->len(), 0, cur_ln));
 	if (len >= lnbf_cpt) { // resize to fit line
 		free(lnbuf);
 		lnbf_cpt = __bit_ceil(len + 1);
@@ -100,8 +100,9 @@ static void apply(uint line, const gap_buf &buf)
 
 	// previous line was a multi-line comment, this might be too
 	if (continued == COMMENT) {
-		ulong pos = lookup2(buf, 0);
-		if (pos == buf.len()) { // still a comment
+		ulong pos = lookup2(*cur_ln->orig, cur_ln->offset);
+		pos -= cur_ln->offset;
+		if (pos == cur_ln->len()) { // still a comment
 			wchgat(text_win, len, 0, COMMENT, 0);
 			return;
 		}
@@ -112,7 +113,7 @@ static void apply(uint line, const gap_buf &buf)
 			return;
 		}
 
-		i = bytes2dchar(pos + 2, 0, buf); // continue from end of comment
+		i = bytes2dchar(pos + 2, 0, cur_ln); // continue from end of comment
 		wchgat(text_win, i, 0, COMMENT, 0);
 	}
 
@@ -127,7 +128,8 @@ static void apply(uint line, const gap_buf &buf)
 		} else if (lnbuf[i] == '/' && lnbuf[i + 1] == '*') {
 			previ = i;
 			i += 2;
-			ulong pos = lookup2(buf, i); // comment might end in this line
+			ulong pos = lookup2(*cur_ln->orig, i + cur_ln->offset); // comment might end in this line
+			pos -= cur_ln->offset;
 
 			i = min(pos + 1, len);
 			if (i >= len - 1) // comment continues in next line
@@ -159,10 +161,10 @@ static void apply(uint line, const gap_buf &buf)
 }
 
 // wrapper for apply()
-void highlight(uint line, const gap_buf &buf)
+void highlight(uint line, const iter *i)
 {
 #ifdef HIGHLIGHT
 	if (eligible)
-		apply(line, buf);
+		apply(line, i);
 #endif
 }

--- a/screen/highlight.cpp
+++ b/screen/highlight.cpp
@@ -57,7 +57,7 @@ static bool binary_search(const char *arr, const uchar *len_arr, uint size, cons
 }
 
 static bool is_separator(char ch) { return (ch > 31 && ch < 48) || (ch > 57 && ch < 65) || (ch > 90 && ch < 95) || ch > 122; }
-static inline ulong lookup2(const gap_buf &buf, ulong i) { // len = 2, boyer-moore is not useful
+static inline uint lookup2(const gap_buf &buf, uint i) { // len = 2, boyer-moore is not useful
 	while (i < buf.len() && !(at(buf, i) == '*' && at(buf, i + 1) == '/'))
 		++i;
 	return i;
@@ -100,7 +100,7 @@ static void apply(uint line, const iter *cur_ln)
 
 	// previous line was a multi-line comment, this might be too
 	if (continued == COMMENT) {
-		ulong pos = lookup2(*cur_ln->orig, cur_ln->offset);
+		uint pos = lookup2(*cur_ln->orig, cur_ln->offset);
 		pos -= cur_ln->offset;
 		if (pos == cur_ln->len()) { // still a comment
 			wchgat(text_win, len, 0, COMMENT, 0);
@@ -128,7 +128,7 @@ static void apply(uint line, const iter *cur_ln)
 		} else if (lnbuf[i] == '/' && lnbuf[i + 1] == '*') {
 			previ = i;
 			i += 2;
-			ulong pos = lookup2(*cur_ln->orig, i + cur_ln->offset); // comment might end in this line
+			uint pos = lookup2(*cur_ln->orig, i + cur_ln->offset); // comment might end in this line
 			pos -= cur_ln->offset;
 
 			i = min(pos + 1, len);

--- a/utils/headers/io.h
+++ b/utils/headers/io.h
@@ -5,11 +5,10 @@ void print2header(const char *msg, uchar pos); // print string to header; pos = 
 char *input_header(const char *q); // return allocated 128 byte string, answer to question q, posted in header
 #define clearline (wmove(text_win, y, 0), wclrtoeol(text_win))
 #define mvprint_line(y, x, buffer, from, to) (wmove(text_win, y, x), print_line(buffer, from, to, y))
-uint print_line(const gap_buf &buffer, uint from, uint to, uint y); // print substring of buffer, to = 0 -> fill line
+uint print_line(const iter *i, uint from, uint to, uint y); // print substring of buffer, to = 0 -> fill line
 void print_text(uint line); // print text string from line
 #define clean_mark(line) (mvwaddch(text_win, (line), maxx - 1, ' '))
 #define print_del_mark(line) {if (overflows[line]) {mvwins_wch(text_win, (line), maxx - 1, &mark);}}
 void print_new_mark();
 void save(); // save buffer to filename
-void read_fgets(FILE *fi); // read file with fgets
-void read_fread(FILE *fi); // read file with fread (faster)
+void read_file(int fd); // read file with fread (faster)

--- a/utils/headers/key_func.h
+++ b/utils/headers/key_func.h
@@ -5,7 +5,7 @@
 void stats(); // print statistics in header
 void command(); // prompt for command
 void enter(); // insert enter at *it,rx and create new node for line
-void mvr_scurs(ulong t_byte); // move right screen cursor
+void mvr_scurs(uint t_byte); // move right screen cursor
 inline void eol() { mvr_scurs(it.len()); overflows[y] = false; }// go to end of line, if necessary cut line mod window width (maxx)
 void sol(); // got to start of line, reset cut, ofx
 void scrolldown(); // scroll one line down, increase y offset and iterate

--- a/utils/headers/key_func.h
+++ b/utils/headers/key_func.h
@@ -6,7 +6,7 @@ void stats(); // print statistics in header
 void command(); // prompt for command
 void enter(); // insert enter at *it,rx and create new node for line
 void mvr_scurs(ulong t_byte); // move right screen cursor
-inline void eol() { mvr_scurs(it->len()); overflows[y] = false; }// go to end of line, if necessary cut line mod window width (maxx)
+inline void eol() { mvr_scurs(it.len()); overflows[y] = false; }// go to end of line, if necessary cut line mod window width (maxx)
 void sol(); // got to start of line, reset cut, ofx
 void scrolldown(); // scroll one line down, increase y offset and iterate
 void scrollup(); // scroll up

--- a/utils/headers/key_func.h
+++ b/utils/headers/key_func.h
@@ -5,6 +5,8 @@
 void stats(); // print statistics in header
 void command(); // prompt for command
 void enter(); // insert enter at *it,rx and create new node for line
+void scroll2(uint a);
+void mvl_scurs(uint t_byte);
 void mvr_scurs(uint t_byte); // move right screen cursor
 inline void eol() { mvr_scurs(it.len()); overflows[y] = false; }// go to end of line, if necessary cut line mod window width (maxx)
 void sol(); // got to start of line, reset cut, ofx

--- a/utils/headers/search.h
+++ b/utils/headers/search.h
@@ -7,4 +7,5 @@ vector<uint> search_a(const gap_buf &buf, const char *str, ushort len);
 vector<vector<uint>> search_la(uint from, uint to, const char *str, ushort len); // use above to search on multiple lines
 uint search_c(const gap_buf &buf, const char *str, ushort len); // same as above, but only counts
 ulong search_lc(uint from, uint to, const char *str, ushort len);
+vector<uint> mt_search(const gap_buf &buf, char ch, bool append);
 void find(const char *str, uint from, uint to, char mode); // wrapper for search_l

--- a/utils/headers/search.h
+++ b/utils/headers/search.h
@@ -6,6 +6,6 @@
 vector<uint> search_a(const gap_buf &buf, const char *str, ushort len);
 vector<vector<uint>> search_la(uint from, uint to, const char *str, ushort len); // use above to search on multiple lines
 uint search_c(const gap_buf &buf, const char *str, ushort len); // same as above, but only counts
-ulong search_lc(uint from, uint to, const char *str, ushort len);
+uint search_lc(uint from, uint to, const char *str, ushort len);
 vector<uint> mt_search(const gap_buf &buf, char ch, bool append);
 void find(const char *str, uint from, uint to, char mode); // wrapper for search_l

--- a/utils/headers/search.h
+++ b/utils/headers/search.h
@@ -1,11 +1,8 @@
 #pragma once
 #include "io.h"
 #include "key_func.h"
+#include "../../ds/headers/dynarray.h"
 
-// search for str in buf, return vector of occurences
-vector<uint> search_a(const gap_buf &buf, const char *str, ushort len);
-vector<vector<uint>> search_la(uint from, uint to, const char *str, ushort len); // use above to search on multiple lines
-uint search_c(const gap_buf &buf, const char *str, ushort len); // same as above, but only counts
-uint search_lc(uint from, uint to, const char *str, ushort len);
-vector<uint> mt_search(const gap_buf &buf, char ch, bool append);
+void search_la(uint from, uint to);
+void search_lc(uint from, uint to);
 void find(const char *str, uint from, uint to, char mode); // wrapper for search_l

--- a/utils/headers/sizes.h
+++ b/utils/headers/sizes.h
@@ -2,14 +2,14 @@
 #include "../../headers/main.h"
 
 char hrsize(size_t bytes, char *dest, ushort dest_cpt); // format bytes
-ulong dchar2bytes(ulong disp_x, ulong from, const gap_buf &buf); // how many bytes are disp_x displayed chars
-ulong bytes2dchar(ulong bytes, ulong from, const gap_buf &buf);
-inline long calc_offset_dis(ulong disp_x, const gap_buf &buf) { // offset until displayed character
-	return (long)dchar2bytes(disp_x, 0, buf) - (long)flag;
+ulong dchar2bytes(ulong disp_x, ulong from, const iter *i); // how many bytes are disp_x displayed chars
+ulong bytes2dchar(ulong bytes, ulong from, const iter *i);
+inline long calc_offset_dis(ulong disp_x, ulong from, const iter *i) { // offset until displayed character
+	return (long)dchar2bytes(disp_x, from, i) - (long)flag;
 }
-inline long calc_offset_act(ulong pos, ulong from, const gap_buf &buf) { // offset from i until byte pos
-	long i = bytes2dchar(pos, from, buf);
-	return (long)flag - i;
+inline long calc_offset_act(ulong pos, ulong from, const iter *i) { // offset from i until byte pos
+	long n = bytes2dchar(pos, from, i);
+	return (long)flag - n;
 }
 ulong mbcnt(const char *str, ulong len); // count multi-byte characters in string
 uint prevdchar(); // left arrow on end of tab; update offset and move cursor

--- a/utils/headers/sizes.h
+++ b/utils/headers/sizes.h
@@ -2,14 +2,14 @@
 #include "../../headers/main.h"
 
 char hrsize(size_t bytes, char *dest, ushort dest_cpt); // format bytes
-ulong dchar2bytes(ulong disp_x, ulong from, const iter *i); // how many bytes are disp_x displayed chars
-ulong bytes2dchar(ulong bytes, ulong from, const iter *i);
-inline long calc_offset_dis(ulong disp_x, ulong from, const iter *i) { // offset until displayed character
+uint dchar2bytes(uint disp_x, uint from, const iter *i); // how many bytes are disp_x displayed chars
+uint bytes2dchar(uint bytes, uint from, const iter *i);
+inline long calc_offset_dis(uint disp_x, uint from, const iter *i) { // offset until displayed character
 	return (long)dchar2bytes(disp_x, from, i) - (long)flag;
 }
-inline long calc_offset_act(ulong pos, ulong from, const iter *i) { // offset from i until byte pos
+inline long calc_offset_act(uint pos, uint from, const iter *i) { // offset from i until byte pos
 	long n = bytes2dchar(pos, from, i);
 	return (long)flag - n;
 }
-ulong mbcnt(const char *str, ulong len); // count multi-byte characters in string
+uint mbcnt(const char *str, uint len); // count multi-byte characters in string
 uint prevdchar(); // left arrow on end of tab; update offset and move cursor

--- a/utils/io.cpp
+++ b/utils/io.cpp
@@ -116,18 +116,18 @@ void save()
 #define gpb i->merged_lines
 	chunk *i = text.head->next;
 	for (uint j = 0; i != text.tail && j < text.nodes; ++j, i = i->next) {
-		fwrite(gpb.buffer(), 1, gpb.gps(), fo);
-		fwrite(gpb.buffer() + gpb.gpe() + 1, 1, gpb.cpt() - gpb.gpe() - 1, fo); // print remaining bytes
+		fwrite(gpb.buffer(), 1, gpb.gps, fo);
+		fwrite(gpb.buffer() + gpb.gpe + 1, 1, gpb.cpt() - gpb.gpe - 1, fo); // print remaining bytes
 	}
 	// last line may have a \0 byte at i->length, don't print it | TODO: simplify
-	ulong end = gpb.gps();
-	if (end > 0 && gpb.buffer()[gpb.gps() - 1] == 0)
+	uint end = gpb.gps;
+	if (end > 0 && gpb.buffer()[gpb.gps - 1] == 0)
 		end--;	
 	fwrite(gpb.buffer(), 1, end, fo);
-	end = gpb.cpt() - gpb.gpe() - 1;
+	end = gpb.cpt() - gpb.gpe - 1;
 	if (end > 0 && gpb.buffer()[gpb.cpt() - 1] == 0)
 		end--;
-	fwrite(gpb.buffer() + gpb.gpe() + 1, 1, end, fo);
+	fwrite(gpb.buffer() + gpb.gpe + 1, 1, end, fo);
 #undef gpb
 	fclose(fo);
 	reset_header();
@@ -138,6 +138,7 @@ void save()
 // For size see: https://github.com/ikozyris/kri/wiki/Comments-on-optimizations#buffer-size-for-reading
 #define SZ 524288 // 512 KiB
 
+// FIXME: this has become a mess
 void read_file(int fd)
 {
 	// TODO: async double buffering

--- a/utils/io.cpp
+++ b/utils/io.cpp
@@ -70,11 +70,12 @@ void print_text(uint line)
 	iterate_fw(&i, ofy + line);
 	wmove(text_win, line, 0);
 	wclrtobot(text_win);
-	wmove(text_win, line, 0);
-	for (uint ty = line; ty <= min(text.lines + ofy, maxy - 1); ++ty) {
+	mvprint_line(line, 0, &i, 0, 0);
+	highlight(line, &i);
+	for (uint ty = line + 1; ty <= min(text.lines + ofy, maxy - 1); ++ty) {
+		iterate_fw(&i, 1);
 		mvprint_line(ty, 0, &i, 0, 0);
 		highlight(ty, &i);
-		iterate_fw(&i, 1);
 	}
 }
 

--- a/utils/io.cpp
+++ b/utils/io.cpp
@@ -71,10 +71,10 @@ void print_text(uint line)
 	wmove(text_win, line, 0);
 	wclrtobot(text_win);
 	wmove(text_win, line, 0);
-	// FIXME: print last line
-	for (uint ty = line; ty < min(text.lines + ofy - 1, maxy) && i.orig != 0; iterate_fw(&i, 1), ++ty) {
+	for (uint ty = line; ty <= min(text.lines + ofy, maxy - 1); ++ty) {
 		mvprint_line(ty, 0, &i, 0, 0);
 		highlight(ty, &i);
+		iterate_fw(&i, 1);
 	}
 }
 
@@ -140,28 +140,43 @@ void save()
 
 void read_file(int fd)
 {
-	// TODO: double buffering
-	char *tmp = (char*)malloc(SZ), *res, *cur;
-	uint a;
-	while ((a = read(fd, tmp, SZ))) {
-		cur = tmp;
+	// TODO: async double buffering
+	char *buf = (char*)malloc(SZ), *res, *cur;
+	char *prev_buf = (char*)malloc(SZ), *prev_cur;
+	cur = prev_buf;
+	uint bread, prev_len = 0; // bytes read
+	chunk *cur_chunk = text.head->next;
+	while ((bread = read(fd, buf, SZ))) {
+		prev_cur = cur;
+		cur = buf;
 		// TODO: multithreaded search?
-		while ((res = (char*)memchr(cur, '\n', tmp + a - cur)) != nullptr) {
+		while ((res = (char*)memchr(cur, '\n', buf + bread - cur)) != nullptr) {
 			uint len = res - cur + 1; // length of this line
-			if (it.parent()->num_lines > 1 && it.orig->len() + len > MAX_CHUNK_SIZE) {
+			if (cur_chunk->num_lines > 1 && cur_chunk->merged_lines.len() + len + prev_len > MAX_CHUNK_SIZE) {
+				text.nodes++;
+				cur_chunk->num_lines--;
 				chunk *new_chunk = create_chunk();
-				insert_chunk(&text, it.parent(), new_chunk);
-				it.orig = &it.parent()->next->merged_lines;
-				it.offset = it.relative_pos = 0;
+				connect(cur_chunk, new_chunk);
+				cur_chunk = new_chunk;
 			}
-			apnd_s(*it.orig, cur, len); // TODO: write directly to gap buffer?
-			append_len(it.parent(), len);
+
+			apnd_s(cur_chunk->merged_lines, prev_cur, prev_len);
+			apnd_s(cur_chunk->merged_lines, cur, len); // TODO: write directly to gap buffer?
+			append_len(cur_chunk, len + prev_len);
 			text.lines++;
 			cur = res + 1;
+			prev_len = 0;
 		}
-		// if last character is not a newline
-		apnd_s(*it.orig, cur, (tmp + a) - cur);
-		it.parent()->len[it.parent()->num_lines - 1] += (tmp + a) - cur;
+		prev_len = (buf + bread) - cur;
+		swap(prev_buf, buf);
+		
 	}
-	free(tmp);
+	if (prev_len) {
+		apnd_s(cur_chunk->merged_lines, cur, prev_len);
+		append_len(cur_chunk, prev_len);
+	}
+	free(buf);
+	free(prev_buf);
+	connect(cur_chunk, text.tail);
+	cur_chunk->num_lines--;
 }

--- a/utils/io.cpp
+++ b/utils/io.cpp
@@ -72,7 +72,7 @@ void print_text(uint line)
 	wclrtobot(text_win);
 	mvprint_line(line, 0, &i, 0, 0);
 	highlight(line, &i);
-	for (uint ty = line + 1; ty <= min(text.lines + ofy, maxy - 1); ++ty) {
+	for (uint ty = line + 1; ty <= min(text.lines - ofy, maxy - 1); ++ty) {
 		iterate_fw(&i, 1);
 		mvprint_line(ty, 0, &i, 0, 0);
 		highlight(ty, &i);

--- a/utils/io.cpp
+++ b/utils/io.cpp
@@ -36,23 +36,23 @@ char *input_header(const char *q)
 }
 
 // prints substring of buffer from: (curr x + 'from' bytes), if (to == 0) print until maxx
-uint print_line(const gap_buf &buffer, uint from, uint to, uint y)
+uint print_line(const iter *i, uint from, uint to, uint y)
 {
 	// only newline or emulated newline ('\0') is in buffer
-	if (buffer.len() <= 1)
+	if (i->len() <= 1)
 		return 0;
 	if (to == 0) {
 		uint prevx = getcurx(text_win); // in case x != 0 (mvprint_line)
-		uint prop = dchar2bytes(maxx - 1 - prevx, from, buffer);
-		if (prop < buffer.len() - 1) {
-			to = prop;
+		uint prop_bytes = dchar2bytes(maxx - 1 - prevx, from, i);
+		if (prop_bytes < i->len() - 1) {
+			to = prop_bytes;
 			overflows[y] = true;
 		} else {
-			to = buffer.len();
+			to = i->len();
 			overflows[y] = false;
 		}
 	}
-	uint rlen = data(buffer, from, to);
+	uint rlen = data(*i->orig, from + i->offset, to + i->offset);
 	if (lnbuf[rlen - 1] == '\n' || lnbuf[rlen - 1] == '\t')
 		--rlen;
 	waddnstr(text_win, lnbuf, rlen);
@@ -64,21 +64,24 @@ uint print_line(const gap_buf &buffer, uint from, uint to, uint y)
 // print text starting from line
 void print_text(uint line)
 {
-	list<gap_buf>::iterator i = text.begin();
-	advance(i, ofy + line);
+	iter i;
+	point2chunk(&i, text.head->next);
+	i.global_pos = 0;
+	iterate_fw(&i, ofy + line);
 	wmove(text_win, line, 0);
 	wclrtobot(text_win);
 	wmove(text_win, line, 0);
-	for (uint ty = line; ty < min(curnum + ofy + 1, maxy) && i != text.end(); ++i, ++ty) {
-		mvprint_line(ty, 0, *i, 0, 0);
-		highlight(ty, *i);
+	// FIXME: print last line
+	for (uint ty = line; ty < min(text.lines + ofy - 1, maxy) && i.orig != 0; iterate_fw(&i, 1), ++ty) {
+		mvprint_line(ty, 0, &i, 0, 0);
+		highlight(ty, &i);
 	}
 }
 
 // deleted a char; the mark moved left | invalidates flag
 void print_new_mark()
 {
-	uint char_pos = dchar2bytes(maxx - 2, 0, *it);
+	uint char_pos = dchar2bytes(maxx - 2, 0, &it);
 	if (flag < maxx - 2) { // after deleting a char, new len could be < maxx
 		if (overflows[y] == true) {
 			overflows[y] = false;
@@ -87,13 +90,13 @@ void print_new_mark()
 		return;
 	}
 	print_del_mark(y);
-	char chp = at(*it, char_pos);
+	char chp = at(*it.orig, char_pos + it.offset);
 	if (chp == '\t')
 		clean_mark(y);
 	else if (chp > 0)
 		mvwaddch(text_win, y, maxx - 2, chp);
 	else if (chp < 0) { // 2 bytes to print
-		char chp2 = at(*it, char_pos + 1);
+		char chp2 = at(*it.orig, char_pos + 1);
 		const char tmp[2] = {chp, chp2};
 		mvwaddnstr(text_win, y, maxx - 2, tmp, 2);
 	}
@@ -110,21 +113,22 @@ void save()
 		wmove(text_win, y, x);
 		return;
 	}
-	list<gap_buf>::iterator i = text.begin();
-	for (uint j = 0; i != text.end() && j < curnum; ++j, ++i) {
-		fwrite(i->buffer(), 1, i->gps(), fo);
-		fwrite(i->buffer() + i->gpe() + 1, 1, i->cpt() - i->gpe() - 1, fo); // print remaining bytes
+#define gpb i->merged_lines
+	chunk *i = text.head->next;
+	for (uint j = 0; i != text.tail && j < text.nodes; ++j, i = i->next) {
+		fwrite(gpb.buffer(), 1, gpb.gps(), fo);
+		fwrite(gpb.buffer() + gpb.gpe() + 1, 1, gpb.cpt() - gpb.gpe() - 1, fo); // print remaining bytes
 	}
 	// last line may have a \0 byte at i->length, don't print it | TODO: simplify
-	ulong end = i->gps();
-	if (end > 0 && i->buffer()[i->gps() - 1] == 0)
+	ulong end = gpb.gps();
+	if (end > 0 && gpb.buffer()[gpb.gps() - 1] == 0)
 		end--;	
-	fwrite(i->buffer(), 1, end, fo);
-	end = i->cpt() - i->gpe() - 1;
-	if (end > 0 && i->buffer()[i->cpt() - 1] == 0)
+	fwrite(gpb.buffer(), 1, end, fo);
+	end = gpb.cpt() - gpb.gpe() - 1;
+	if (end > 0 && gpb.buffer()[gpb.cpt() - 1] == 0)
 		end--;
-	fwrite(i->buffer() + i->gpe() + 1, 1, end, fo);
-
+	fwrite(gpb.buffer() + gpb.gpe() + 1, 1, end, fo);
+#undef gpb
 	fclose(fo);
 	reset_header();
 	print2header("Saved", 1);
@@ -134,36 +138,30 @@ void save()
 // For size see: https://github.com/ikozyris/kri/wiki/Comments-on-optimizations#buffer-size-for-reading
 #define SZ 524288 // 512 KiB
 
-void read_fgets(FILE *fi)
+void read_file(int fd)
 {
-	char *tmp = (char*)malloc(SZ);
-	while ((fgets_unlocked(tmp, SZ, fi))) {
-		apnd_s(*it, tmp);
-		if (it->buffer()[it->len() - 1] == '\n') { [[unlikely]]
-			if (++curnum >= text.size()) [[unlikely]]
-				text.resize(text.size() * 2);
-			++it;
-		}
-	}
-	free(tmp);
-}
-
-void read_fread(FILE *fi)
-{
+	// TODO: double buffering
 	char *tmp = (char*)malloc(SZ), *res, *cur;
 	uint a;
-	while ((a = fread(tmp, sizeof(tmp[0]), SZ, fi))) {
+	while ((a = read(fd, tmp, SZ))) {
 		cur = tmp;
 		// TODO: multithreaded search?
 		while ((res = (char*)memchr(cur, '\n', tmp + a - cur)) != nullptr) {
-			apnd_s(*it, cur, (uint)(res - cur) + 1);
+			uint len = res - cur + 1; // length of this line
+			if (it.parent()->num_lines > 1 && it.orig->len() + len > MAX_CHUNK_SIZE) {
+				chunk *new_chunk = create_chunk();
+				insert_chunk(&text, it.parent(), new_chunk);
+				it.orig = &it.parent()->next->merged_lines;
+				it.offset = it.relative_pos = 0;
+			}
+			apnd_s(*it.orig, cur, len); // TODO: write directly to gap buffer?
+			append_len(it.parent(), len);
+			text.lines++;
 			cur = res + 1;
-			if (++curnum >= text.size())
-				text.resize(text.size() * 2);
-			++it;
 		}
 		// if last character is not a newline
-		apnd_s(*it, cur, (tmp + a) - cur);
+		apnd_s(*it.orig, cur, (tmp + a) - cur);
+		it.parent()->len[it.parent()->num_lines - 1] += (tmp + a) - cur;
 	}
 	free(tmp);
 }

--- a/utils/key_func.cpp
+++ b/utils/key_func.cpp
@@ -10,14 +10,14 @@ void stats()
 		cutb = cut.back().byte;
 		cutd = cut.back().dchar;
 	}
-	snprintf(_tmp, min(maxx, 256), "maxx %u off %u len %lu gs %lu ge %lu cpt %lu cut%lu[d%u,b%u] x %u ofx %ld ry %lu lines %u   ",
+	snprintf(_tmp, min(maxx, 256), "maxx %u off %u len %u gs %u ge %u cpt %u cut%lu[d%u,b%u] x %u ofx %ld ry %u lines %u   ",
 	maxx, it.offset, it.len(), it.gps(), it.gpe(), it.cpt(), cut.size(), cutd, cutb, x, ofx, ry, text.lines);
 #else	
 	ulong sumlen = 0;
 	chunk *i;
 	for (i = text.head->next; i != text.tail; i = i->next)
 		sumlen += i->merged_lines.len();
-	snprintf(_tmp, min(maxx, 256), "len %lu  cpt %lu  y %lu  x %u  sum len %lu  lines %u  cut %lu  ofx %ld  ", 
+	snprintf(_tmp, min(maxx, 256), "len %u  cpt %u  y %u  x %u  sum len %lu  lines %u  cut %lu  ofx %ld  ", 
 		it.len(), it.cpt(), ry, x, sumlen, text.lines, cut.size(), ofx);
 #endif
 	print2header(_tmp, 1);
@@ -117,7 +117,7 @@ void enter()
 	
 	text.lines++;
 	insert_c(*it.orig, '\n');
-	it.offset = it.orig->gps();
+	it.offset = it.orig->gps;
 	it.relative_pos++;
 	if (it.orig->len() > MAX_CHUNK_SIZE)
 		split_mline(&text, it.parent());
@@ -129,7 +129,7 @@ void enter()
 		wmove(text_win, y + 1, 0);
 	else { // y = maxy; scroll
 		wscrl(ln_win, 1);
-		mvwprintw(ln_win, maxy - 1, 0, "%3lu", ry + 2);
+		mvwprintw(ln_win, maxy - 1, 0, "%3u", ry + 2);
 		wnoutrefresh(ln_win);
 		wscrl(text_win, 1);
 		++ofy;
@@ -139,14 +139,14 @@ void enter()
 }
 
 // go to target byte, if necessary cut line
-void mvr_scurs(ulong t_byte)
+void mvr_scurs(uint t_byte)
 {
 	ofx = calc_offset_act(t_byte, 0, &it);
 	if (t_byte - ofx <= maxx) // line fits in screen
 		wmove(text_win, y, t_byte - ofx - 1);
 	else { // cut line 
 		cut.clear();
-		ulong bytes = 0;
+		uint bytes = 0;
 		if (ofx == 0 && t_byte > (uint)5e8) {
 			while (bytes + maxx < t_byte) {
 				bytes += maxx - 1;
@@ -156,7 +156,7 @@ void mvr_scurs(ulong t_byte)
 			flag = t_byte % (maxx - 1);
 		} else {
 			while (1) { // TODO: optimize
-				const ulong nbytes = dchar2bytes(maxx - 1, bytes, &it);
+				const uint nbytes = dchar2bytes(maxx - 1, bytes, &it);
 				if (nbytes >= t_byte - 1)
 					break;
 				cut.push_back({flag, nbytes}); // flag was changed by dchar2bytes
@@ -200,7 +200,7 @@ void scrolldown()
 	ofx = 0;
 	wscrl(text_win, 1);
 	wscrl(ln_win, 1);
-	mvwprintw(ln_win, maxy - 1, 0, "%3lu", ry + 2);
+	mvwprintw(ln_win, maxy - 1, 0, "%3u", ry + 2);
 	wnoutrefresh(ln_win);
 	mvprint_line(y, 0, &it, 0, 0);
 	highlight(y, &it);
@@ -216,7 +216,7 @@ void scrollup()
 	ofx = 0;
 	wscrl(text_win, -1);
 	wscrl(ln_win, -1);
-	mvwprintw(ln_win, 0, 0, "%3lu", ry);
+	mvwprintw(ln_win, 0, 0, "%3u", ry);
 	wnoutrefresh(ln_win);
 	mvprint_line(0, 0, &it, 0, 0);
 	highlight(0, &it);

--- a/utils/key_func.cpp
+++ b/utils/key_func.cpp
@@ -4,20 +4,20 @@
 void stats()
 {
 	char *_tmp = (char*)malloc(256);
-	ulong sumlen = 0;
-	// for (auto &i : text)
-		// sumlen += i.len();
 #ifndef RELEASE
 	uint cutd = 0, cutb = 0;
 	if (!cut.empty()) {
 		cutb = cut.back().byte;
 		cutd = cut.back().dchar;
 	}
-	snprintf(_tmp, min(maxx, 256), "maxx %u off %u len %u gs %u ge %u cpt %u cut%lu[d%u,b%u] x: %u ofx: %ld ry: %lu     ",
-		maxx, it.offset, it.len(), it.gps(), it.gpe(), it.cpt(), cut.size(), cutd, cutb, x, ofx, ry);
+	snprintf(_tmp, min(maxx, 256), "maxx %u off %u len %lu gs %lu ge %lu cpt %lu cut%lu[d%u,b%u] x %u ofx %ld ry %lu lines %u   ",
+	maxx, it.offset, it.len(), it.gps(), it.gpe(), it.cpt(), cut.size(), cutd, cutb, x, ofx, ry, text.lines);
 #else	
+	ulong sumlen = 0;
+	// for (auto &i : text)
+		// sumlen += i.len();
 	snprintf(_tmp, min(maxx, 256), "len %lu  cpt %lu  y %lu  x %u  sum len %lu  lines %lu  cut %lu  ofx %ld  ", 
-		it.len(), it.cpt(), ry, x, sumlen, text.size, cut.size(), ofx);
+		it.len(), it.cpt(), ry, x, sumlen, text.lines, cut.size(), ofx);
 #endif
 	print2header(_tmp, 1);
 	free(_tmp);

--- a/utils/key_func.cpp
+++ b/utils/key_func.cpp
@@ -5,19 +5,19 @@ void stats()
 {
 	char *_tmp = (char*)malloc(256);
 	ulong sumlen = 0;
-	for (auto &i : text)
-		sumlen += i.len();
+	// for (auto &i : text)
+		// sumlen += i.len();
 #ifndef RELEASE
 	uint cutd = 0, cutb = 0;
 	if (!cut.empty()) {
 		cutb = cut.back().byte;
 		cutd = cut.back().dchar;
 	}
-	snprintf(_tmp, min(maxx, 256), "maxx %u len %lu gs %lu ge %lu cpt %lu cut%lu[d%u,b%u] x: %u ofx: %ld ry: %lu     ",
-		maxx, it->len(), it->gps(), it->gpe(), it->cpt(), cut.size(), cutd, cutb, x, ofx, ry);
+	snprintf(_tmp, min(maxx, 256), "maxx %u off %u len %u gs %u ge %u cpt %u cut%lu[d%u,b%u] x: %u ofx: %ld ry: %lu     ",
+		maxx, it.offset, it.len(), it.gps(), it.gpe(), it.cpt(), cut.size(), cutd, cutb, x, ofx, ry);
 #else	
 	snprintf(_tmp, min(maxx, 256), "len %lu  cpt %lu  y %lu  x %u  sum len %lu  lines %lu  cut %lu  ofx %ld  ", 
-		it->len(), it->cpt(), ry, x, sumlen, curnum, cut.size(), ofx);
+		it.len(), it.cpt(), ry, x, sumlen, text.size, cut.size(), ofx);
 #endif
 	print2header(_tmp, 1);
 	free(_tmp);
@@ -32,16 +32,13 @@ void command()
 		reset_header();
 	else if (strcmp(tmp, "shrink") == 0) {
 		char buffer[64] = "";
-		snprintf(buffer, 64, "freed: %lu B", lnbf_cpt - 16 +
-			sizeof(list<gap_buf>) * (text.size() - curnum));
+		snprintf(buffer, 64, "freed: %u B", lnbf_cpt);
 		clear_header();
 		print2header(buffer, 1);
 
 		// shrink line buffer
 		lnbf_cpt = 16;
 		lnbuf = (char*)realloc(lnbuf, lnbf_cpt);
-                // shrink linked list
-                text.resize(curnum + 1);
 	} else if (strcmp(tmp, "stats") == 0)
 		stats();
 	else if (strcmp(tmp, "suspend") == 0) {
@@ -53,22 +50,22 @@ void command()
 	else if (strncmp(tmp, "scroll", 6) == 0) {
 		uint a;
 		sscanf(tmp + 7, "%u", &a);
-		if (a <= curnum) {
+		if (a <= text.lines) {
 			ofy = a - 1;
 			print_lines();
 			wrefresh(ln_win);
 			print_text(0);
-			advance(it, ofy - ry);
+			iterate_fw(&it, ofy - ry);
 		}
 	} else if (strncmp(tmp, "find", 4) == 0) { // example: find string
-		uint from = 0, to = curnum;
+		uint from = 0, to = text.lines;
 		char mode = 'h';
 		char *pr2 = input_header("range/mode: "); // 5-10 h
 		sscanf(pr2, "%u-%u %c", &from, &to, &mode);
 		free(pr2);
-		find(tmp + 5, from, to + 1, mode); // we want closed interval, function is open
+		//find(tmp + 5, from, to + 1, mode); // we want closed interval, function is open
 	} else if (strncmp(tmp, "replace", 7) == 0) {
-		uint from = 0, to = curnum;
+		/*uint from = 0, to = text.lines;
 		sscanf(tmp + 8, "%u-%u", &from, &to);
 		free(tmp);
 
@@ -96,7 +93,7 @@ void command()
 		print2header(tmp_buff, 1);
 		print_text(0);
 		free(newst);
-		free(tmp_buff);
+		free(tmp_buff);*/
 	} else
 		print2header("command not found", 3);
 	free(tmp);
@@ -105,23 +102,26 @@ void command()
 // insert enter in rx of buffer, create new line node and reprint
 void enter()
 {
-	insert_c(*it, rx, '\n');
-	gap_buf *t = (gap_buf*)malloc(sizeof(gap_buf));
-	init(*t);
-	/* If buffer's last char is a newline; rx = it->len - 1; gpe = cpt - 2
-	 * so the last character (newline or emulated) will be copied over
-	 * Otherwise, (x != EOL) copy the remaining bytes
-	 */
-	data(*it, rx + 1, it->len() + 1);
-	apnd_s(*t, lnbuf, it->len() - rx - 1);
-	it->set_gps(rx + 1);
-	it->set_gpe(it->cpt() - 1);
+	chunk *ch = it.parent();
+	uint pos = it.relative_pos;
 
-	++it; // insert is on previous than current it
-	++curnum;
-	text.insert(it, *t); // insert new node with text after rx
-	--it;
-	free(t);
+	if (ch->len_cpt < ch->num_lines + 1) {
+		ch->len_cpt = (1 + ch->len_cpt) * 2;
+		ch->len = (uchar*)realloc(ch->len, ch->len_cpt);
+	}
+	memmove(&ch->len[pos + 1], &ch->len[pos], ch->num_lines - pos);
+	ch->num_lines++;
+	ch->len[pos + 1] = it.len() - it.gps();
+	ch->len[pos] = it.gps() + 1;
+	
+	text.lines++;
+	insert_c(*it.orig, '\n');
+	it.offset = it.orig->gps();
+	it.relative_pos++;
+	if (it.orig->len() > 256)
+		split_mline(&text, it.parent());
+
+	ofx = 0;
 	cut.clear();
 	print_text(y);
 	if (y < maxy - 1)
@@ -132,16 +132,15 @@ void enter()
 		wnoutrefresh(ln_win);
 		wscrl(text_win, 1);
 		++ofy;
-		mvprint_line(maxy - 1, 0, *it, 0, 0);
+		mvprint_line(maxy - 1, 0, &it, 0, 0);
 		wmove(text_win, maxy - 1, x);
 	}
-	ofx = 0;
 }
 
 // go to target byte, if necessary cut line
 void mvr_scurs(ulong t_byte)
 {
-	ofx = calc_offset_act(t_byte, 0, *it);
+	ofx = calc_offset_act(t_byte, 0, &it);
 	if (t_byte - ofx <= maxx) // line fits in screen
 		wmove(text_win, y, t_byte - ofx - 1);
 	else { // cut line 
@@ -156,7 +155,7 @@ void mvr_scurs(ulong t_byte)
 			flag = t_byte % (maxx - 1);
 		} else {
 			while (1) {
-				const ulong nbytes = dchar2bytes(maxx - 1, bytes, *it);
+				const ulong nbytes = dchar2bytes(maxx - 1, bytes, &it);
 				if (nbytes >= t_byte - 1)
 					break;
 				cut.push_back({flag, nbytes}); // flag was changed by dchar2bytes
@@ -164,13 +163,13 @@ void mvr_scurs(ulong t_byte)
 				bytes = nbytes;
 			}
 		}
-		if (t_byte != it->len()) {
-			mvprint_line(y, 0, *it, bytes, 0);
+		if (t_byte != it.len()) {
+			mvprint_line(y, 0, &it, bytes, 0);
 			if (!overflows[y])
 				clean_mark(y);
-			x = bytes2dchar(t_byte, bytes, *it) - 1;
+			x = bytes2dchar(t_byte, bytes, &it) - 1;
 		} else {
-			mvprint_line(y, 0, *it, bytes, t_byte);
+			mvprint_line(y, 0, &it, bytes, t_byte);
 			clean_mark(y);
 			x = (flag == maxx - 1 ? flag : flag - 1);
 		}
@@ -184,8 +183,8 @@ void mvr_scurs(ulong t_byte)
 void sol()
 {
 	if (!cut.empty()) { // line has been cut
-		mvprint_line(y, 0, *it, 0, 0);
-		highlight(y, *it);
+		mvprint_line(y, 0, &it, 0, 0);
+		highlight(y, &it);
 	}
 	cut.clear();
 	wmove(text_win, y, ofx = 0);
@@ -194,7 +193,7 @@ void sol()
 // scroll screen down, print last line
 void scrolldown()
 {
-	++it;
+	iterate_fw(&it, 1);
 	++ofy;
 	cut.clear();
 	ofx = 0;
@@ -202,8 +201,8 @@ void scrolldown()
 	wscrl(ln_win, 1);
 	mvwprintw(ln_win, maxy - 1, 0, "%3lu", ry + 2);
 	wnoutrefresh(ln_win);
-	mvprint_line(y, 0, *it, 0, 0);
-	highlight(y, *it);
+	mvprint_line(y, 0, &it, 0, 0);
+	highlight(y, &it);
 	wmove(text_win, y, 0);
 }
 
@@ -211,15 +210,15 @@ void scrolldown()
 void scrollup()
 {
 	--ofy;
-	--it;
+	iterate_bw(&it, 1);
 	cut.clear();
 	ofx = 0;
 	wscrl(text_win, -1);
 	wscrl(ln_win, -1);
 	mvwprintw(ln_win, 0, 0, "%3lu", ry);
 	wnoutrefresh(ln_win);
-	mvprint_line(0, 0, *it, 0, 0);
-	highlight(0, *it);
+	mvprint_line(0, 0, &it, 0, 0);
+	highlight(0, &it);
 	wmove(text_win, 0, 0);
 }
 
@@ -234,21 +233,21 @@ ushort left()
 		clearline;
 		ofx -= cut.back().dchar;
 		cut.pop_back();
-		print_line(*it, cut.empty() ? 0 : cut.back().byte, 0, y);
+		print_line(&it, cut.empty() ? 0 : cut.back().byte, 0, y);
 		const uint tmp = flag; // changed later by highlight
-		highlight(y, *it);
+		highlight(y, &it);
 		wmove(text_win, y, tmp);
 		return CUT;
 	} else if (x > 0) { // go left
 		wmove(text_win, y, x - 1);
 		// handle special characters causing offsets
-		if (it->buffer()[it->gps() - 1] == '\t')
+		if (it.buffer()[it.gps() - 1] == '\t')
 			ofx += prevdchar();
-		else if (it->buffer()[it->gps() - 1] < 0)
+		else if (it.buffer()[it.gps() - 1] < 0)
 			--ofx;
 		return NORMAL;
 	} else if (y > 0) { // x = 0
-		--it;
+		iterate_bw(&it, 1);
 		--y;
 		eol();
 		return LN_CHANGE;
@@ -258,14 +257,14 @@ ushort left()
 
 // right arrow
 ushort right() {
-	if (rx >= it->len() - 1 && ry < curnum) { // go to next line
+	if (rx >= it.len() - 1 && ry < text.lines - 1) { // go to next line
 		if (y == maxy - 1) {
 			scrolldown();
 			return SCROLL;
 		} else if (!cut.empty()) // revert cut
-			mvprint_line(y, 0, *it, 0, 0);
+			mvprint_line(y, 0, &it, 0, 0);
 		wmove(text_win, y + 1, 0);
-		++it;
+		iterate_fw(&it, 1);
 		cut.clear();
 		ofx = 0;
 		return LN_CHANGE;
@@ -273,17 +272,17 @@ ushort right() {
 cut_line:
 		clearline;
 		ofx += x;
-		cut.push_back({x, (cut.empty() ? 0 : cut.back().byte) + print_line(*it, ofx, 0, y)});
+		cut.push_back({x, (cut.empty() ? 0 : cut.back().byte) + print_line(&it, ofx, 0, y)});
 		wmove(text_win, y, 0);
 		return CUT;
 	} else { // go right
 		wmove(text_win, y, x + 1);
-		if (it->buffer()[it->gpe() + 1] == '\t') {
+		if (it.buffer()[it.gpe() + 1] == '\t') {
 			if (x >= maxx - 7)
 				goto cut_line;
 			ofx -= 8 - x % 8 - 1;
 			wmove(text_win, y, x + 8 - x % 8);
-		} else if (it->buffer()[it->gpe() + 1] < 0)
+		} else if (it.buffer()[it.gpe() + 1] < 0)
 			++ofx;
 		return NORMAL;
 	}
@@ -297,7 +296,7 @@ void prnxt_word(ushort func(void))
 	do {
 		status = func();
 		x = getcurx(text_win);
-		mv_curs(*it, x + ofx);
+		mv_curs(*it.orig, x + ofx);
 	} while ((winch(text_win) & A_CHARTEXT) != ' ' && status == NORMAL);
 }
 
@@ -305,7 +304,8 @@ void reset_view()
 {
 	ofy = ofx = 0;
 	cut.clear();
-	it = text.begin();
+	point2chunk(&it, text.head->next);
+	it.relative_pos = it.global_pos = 0;
 	print_text(0);
 	reset_header();
 	print_lines();

--- a/utils/key_func.cpp
+++ b/utils/key_func.cpp
@@ -14,9 +14,10 @@ void stats()
 	maxx, it.offset, it.len(), it.gps(), it.gpe(), it.cpt(), cut.size(), cutd, cutb, x, ofx, ry, text.lines);
 #else	
 	ulong sumlen = 0;
-	// for (auto &i : text)
-		// sumlen += i.len();
-	snprintf(_tmp, min(maxx, 256), "len %lu  cpt %lu  y %lu  x %u  sum len %lu  lines %lu  cut %lu  ofx %ld  ", 
+	chunk *i;
+	for (i = text.head->next; i != text.tail; i = i->next)
+		sumlen += i->merged_lines.len();
+	snprintf(_tmp, min(maxx, 256), "len %lu  cpt %lu  y %lu  x %u  sum len %lu  lines %u  cut %lu  ofx %ld  ", 
 		it.len(), it.cpt(), ry, x, sumlen, text.lines, cut.size(), ofx);
 #endif
 	print2header(_tmp, 1);
@@ -118,7 +119,7 @@ void enter()
 	insert_c(*it.orig, '\n');
 	it.offset = it.orig->gps();
 	it.relative_pos++;
-	if (it.orig->len() > 256)
+	if (it.orig->len() > MAX_CHUNK_SIZE)
 		split_mline(&text, it.parent());
 
 	ofx = 0;
@@ -154,7 +155,7 @@ void mvr_scurs(ulong t_byte)
 			}
 			flag = t_byte % (maxx - 1);
 		} else {
-			while (1) {
+			while (1) { // TODO: optimize
 				const ulong nbytes = dchar2bytes(maxx - 1, bytes, &it);
 				if (nbytes >= t_byte - 1)
 					break;
@@ -257,7 +258,7 @@ ushort left()
 
 // right arrow
 ushort right() {
-	if (rx >= it.len() - 1 && ry < text.lines - 1) { // go to next line
+	if (rx >= it.len() - 1 && ry < text.lines) { // go to next line
 		if (y == maxy - 1) {
 			scrolldown();
 			return SCROLL;

--- a/utils/key_func.cpp
+++ b/utils/key_func.cpp
@@ -278,7 +278,7 @@ ushort left()
 // right arrow
 ushort right() {
 	// let len overflow if 0
-	if (rx >= it.len() - 1) { // go to next line
+	if (rx >= it.len() - 1 && ry < text.lines) { // go to next line
 		if (y == maxy - 1) {
 			scrolldown();
 			return SCROLL;
@@ -296,7 +296,7 @@ cut_line:
 		cut.push_back({x, (cut.empty() ? 0 : cut.back().byte) + print_line(&it, ofx, 0, y)});
 		wmove(text_win, y, 0);
 		return CUT;
-	} else if (ry < text.lines) { // go right
+	} else if (rx < it.len()) { // go right
 		wmove(text_win, y, x + 1);
 		if (it.buffer()[it.gpe() + 1] == '\t') {
 			if (x >= maxx - 7)

--- a/utils/key_func.cpp
+++ b/utils/key_func.cpp
@@ -12,12 +12,12 @@ void stats()
 	}
 	snprintf(_tmp, min(maxx, 256), "maxx %u off %u len %u gs %u ge %u cpt %u cut%lu[d%u,b%u] x %u ofx %ld ry %u lines %u   ",
 	maxx, it.offset, it.len(), it.gps(), it.gpe(), it.cpt(), cut.size(), cutd, cutb, x, ofx, ry, text.lines);
-#else	
+#else
 	ulong sumlen = 0;
 	chunk *i;
 	for (i = text.head->next; i != text.tail; i = i->next)
 		sumlen += i->merged_lines.len();
-	snprintf(_tmp, min(maxx, 256), "len %u  cpt %u  y %u  x %u  sum len %lu  lines %u  cut %lu  ofx %ld  ", 
+	snprintf(_tmp, min(maxx, 256), "len %u  cpt %u  y %u  x %u  sum len %lu  lines %u  cut %lu  ofx %ld  ",
 		it.len(), it.cpt(), ry, x, sumlen, text.lines, cut.size(), ofx);
 #endif
 	print2header(_tmp, 1);
@@ -52,10 +52,7 @@ void command()
 		uint a;
 		sscanf(tmp + 7, "%u", &a);
 		if (a <= text.lines) {
-			ofy = a - 1;
-			print_lines();
-			wrefresh(ln_win);
-			print_text(0);
+			scroll2(a);
 			iterate_fw(&it, ofy - ry);
 		}
 	} else if (strncmp(tmp, "find", 4) == 0) { // example: find string
@@ -100,6 +97,16 @@ void command()
 	free(tmp);
 }
 
+void scroll2(uint a)
+{
+	ofy = a - 1;
+	ofx = 0;
+	cut.clear();
+	print_lines();
+	wrefresh(ln_win);
+	print_text(0);
+}
+
 // insert enter in rx of buffer, create new line node and reprint
 void enter()
 {
@@ -114,7 +121,7 @@ void enter()
 	ch->num_lines++;
 	ch->len[pos + 1] = it.len() - it.gps();
 	ch->len[pos] = it.gps() + 1;
-	
+
 	text.lines++;
 	insert_c(*it.orig, '\n');
 	it.offset = it.orig->gps;
@@ -144,7 +151,7 @@ void mvr_scurs(uint t_byte)
 	ofx = calc_offset_act(t_byte, 0, &it);
 	if (t_byte - ofx <= maxx) // line fits in screen
 		wmove(text_win, y, t_byte - ofx - 1);
-	else { // cut line 
+	else { // cut line
 		cut.clear();
 		uint bytes = 0;
 		if (ofx == 0 && t_byte > (uint)5e8) {
@@ -174,10 +181,19 @@ void mvr_scurs(uint t_byte)
 			clean_mark(y);
 			x = (flag == maxx - 1 ? flag : flag - 1);
 		}
-		if (x + (uint)ofx > t_byte) 
+		if (x + (uint)ofx > t_byte)
 			ofx = t_byte - x + 1;
 		wmove(text_win, y, x);
 	}
+}
+
+void mvl_scurs(uint t_byte)
+{
+	while (cut.back().byte > t_byte) {
+		ofx -= cut.back().dchar;
+		cut.pop_back();
+	}
+	mvprint_line(y, 0, &it, cut.back().byte, 0);
 }
 
 // go to start-of-line, uncut line if needed
@@ -258,7 +274,8 @@ ushort left()
 
 // right arrow
 ushort right() {
-	if (rx >= it.len() - 1 && ry < text.lines) { // go to next line
+	// let len overflow if 0
+	if (rx >= it.len() - 1) { // go to next line
 		if (y == maxy - 1) {
 			scrolldown();
 			return SCROLL;
@@ -276,7 +293,7 @@ cut_line:
 		cut.push_back({x, (cut.empty() ? 0 : cut.back().byte) + print_line(&it, ofx, 0, y)});
 		wmove(text_win, y, 0);
 		return CUT;
-	} else { // go right
+	} else if (ry < text.lines) { // go right
 		wmove(text_win, y, x + 1);
 		if (it.buffer()[it.gpe() + 1] == '\t') {
 			if (x >= maxx - 7)
@@ -305,8 +322,7 @@ void reset_view()
 {
 	ofy = ofx = 0;
 	cut.clear();
-	point2chunk(&it, text.head->next);
-	it.relative_pos = it.global_pos = 0;
+	point2begin(&it);
 	print_text(0);
 	reset_header();
 	print_lines();

--- a/utils/key_func.cpp
+++ b/utils/key_func.cpp
@@ -61,9 +61,10 @@ void command()
 		char *pr2 = input_header("range/mode: "); // 5-10 h
 		sscanf(pr2, "%u-%u %c", &from, &to, &mode);
 		free(pr2);
-		//find(tmp + 5, from, to + 1, mode); // we want closed interval, function is open
+		tmp[4] = strlen(tmp + 5); // pascal string
+		find(tmp + 4, from, to + 1, mode); // we want closed interval, function is open
 	} else if (strncmp(tmp, "replace", 7) == 0) {
-		/*uint from = 0, to = text.lines;
+/*		uint from = 0, to = text.lines;
 		sscanf(tmp + 8, "%u-%u", &from, &to);
 		free(tmp);
 
@@ -73,15 +74,16 @@ void command()
 		long offset = 0;
 		uint count = 0;
 
-		list<gap_buf>::iterator iter = text.begin();
-		advance(iter, from);
-		for (uint i = from; i <= to; ++i, ++iter) {
-			vector<uint> matches = search_a(*iter, tmp, tmp_len);
+		iter tmp_it;
+		point2begin(&tmp_it);
+		iterate_fw(&tmp_it, from);
+		for (uint i = from; i <= to; ++i, iterate_fw(&tmp_it, 1)) {
+			vector<uint> matches = search_a(*tmp_it.orig, tmp);
 			count += matches.size();
 			for (uint j = 0; j < matches.size(); ++j) {
-				mv_curs(*iter, (long)matches[j] + offset);
-				iter->set_gpe(iter->gpe() + tmp_len);
-				insert_s(*iter, matches[j] + offset, newst, newst_len);
+				mv_curs(*tmp_it.orig, (long)matches[j] + offset);
+				tmp_it.set_gpe(tmp_it.gpe() + tmp_len);
+				insert_s(*tmp_it.orig, newst, newst_len);
 				offset += (long)newst_len - (long)tmp_len;
 			}
 			offset = 0;
@@ -145,6 +147,7 @@ void enter()
 	}
 }
 
+// TODO: this is a repetitive mess
 // go to target byte, if necessary cut line
 void mvr_scurs(uint t_byte)
 {
@@ -164,7 +167,7 @@ void mvr_scurs(uint t_byte)
 		} else {
 			while (1) { // TODO: optimize
 				const uint nbytes = dchar2bytes(maxx - 1, bytes, &it);
-				if (nbytes >= t_byte - 1)
+				if (nbytes > t_byte)
 					break;
 				cut.push_back({flag, nbytes}); // flag was changed by dchar2bytes
 				ofx += flag;

--- a/utils/search.cpp
+++ b/utils/search.cpp
@@ -4,7 +4,7 @@
 void find(const char *str, uint from, uint to, char mode)
 {
 	uint str_len = strlen(str);
-	if (str_len == 0 || to - 1 > curnum || from > to) {
+	if (str_len == 0 || to - 1 > text.size || from > to) {
 		print2header("Invalid parameters", 1);
 		return;
 	}
@@ -61,7 +61,7 @@ void find(const char *str, uint from, uint to, char mode)
 		case KEY_DOWN:
 			for (uint i = from; i < first_batch; ++i)
 				dix[i] = previ[i] = prevpr[i] = prevx[i] = 0;
-			if (ofy + maxy > min(curnum, to))
+			if (ofy + maxy > min(text.size, to))
 				break;
 			++ofy;
 			++it;
@@ -286,9 +286,10 @@ static void searchch_c(const gap_buf &buf, char ch, ulong st, ulong end, uint &c
 }
 
 // wrapper for searchch() to launch with multi-threaded
-static vector<uint> mt_search(const gap_buf &buf, char ch, bool append)
+vector<uint> mt_search(const gap_buf &buf, char ch, bool append)
 {
 	uint nthreads, chunk;
+	// TODO: partition smarter: before gap + after gap
 	partition_chunks(nthreads, chunk, 0, buf.len() - 1); // -1 as last char is \n
 	vector<thread> threads(nthreads);
 	vector<vector<uint>> indices(nthreads); // each thread's result

--- a/utils/search.cpp
+++ b/utils/search.cpp
@@ -1,349 +1,347 @@
 #include "headers/search.h"
 
+// global is occurrences, each local is matches
+static vector<dynarray> occurrences(4);
+// shared parameters
+static const char *string;
+static bool append;
+static iter first_line;
+static iter last_line;
+
+// TODO: give hint of left/right bound based on cur_occ
+static uint ln_start(const vector<pair<uint, uint>> &yx, uint y) {
+	uint lo = 0, hi = yx.size() - 1, mid;
+	while (lo < hi) {
+		mid = lo + (hi - lo) / 2;
+		if (yx[mid].first < y)
+			lo = mid + 1;
+		else
+			hi = mid; // find leftmost occurrence
+	}
+	return lo;
+}
+
+static pair<uint, uint> index2yx(uint index, iter *it)
+{
+	uint cbyte = 0;
+	const chunk *ch = it->parent();
+	for (uint i = 0; i < ch->num_lines; ++i) {
+		if (index < cbyte + ch->len[i]) {
+			uint dx = bytes2dchar(index, cbyte, it);
+			if (dx >= maxx - 1) // if it's outside of visible range we don't need this
+				dx = index;
+			return {i, dx};
+		}
+		cbyte += ch->len[i];
+	}
+	return {index, 0}; // only one line is in chunk
+}
+
+static void highlight_occ(const vector<pair<uint,uint>> &matches, uint cur_occ)
+{
+	if (matches[cur_occ].first - ofy == 0) // first line may have offset on x axis
+		mvwchgat(text_win, 0, matches[cur_occ].second - ofx,
+			string[0], A_STANDOUT, 0, 0);
+	while (cur_occ < matches.size()) {
+		if (matches[cur_occ].first >= maxy + ofy)
+			break;
+		if (matches[cur_occ].second < maxx) // ignored on handled above
+			mvwchgat(text_win, (uint)matches[cur_occ].first - ofy, matches[cur_occ].second,
+				string[0], A_STANDOUT, 0, 0);
+		cur_occ++;
+	}
+}
+
+static void *_search_lc(void *args);
+static void *_search_la(void *args);
+static void search_mb_common(uint from, uint to, void *search_fn(void*));
+
 // highlight or count occurrences of str in range [from, to)
 void find(const char *str, uint from, uint to, char mode)
 {
-	uint str_len = strlen(str);
-	if (str_len == 0 || to - 1 > text.size || from > to) {
+	uint str_len = str[0];
+	if (str_len == 0 || to - 1 > text.lines || from > to) {
 		print2header("Invalid parameters", 1);
 		return;
 	}
 
-	list<gap_buf>::iterator tmp_it = text.begin();
-	advance(tmp_it, from);
+	iter tmp_it;
+	point2begin(&tmp_it);
+	iterate_fw(&tmp_it, from);
 	it = tmp_it;
-	const ulong first_batch = min(maxy, to); // how many lines to display
-	vector<vector<uint>> matches;
+	append = mode == 'h';
+
+	string = str;
+	if (append)
+		search_mb_common(from, to, _search_la);
+	else
+		search_mb_common(from, to, _search_lc);
 	ulong total = 0;
-	if (mode == 'h') {
-		// fetches only the occurrences that will be shown +1
-		matches = search_la(from, from + first_batch + 1, str, str_len);
-		for (const auto &vec : matches)
-			total += vec.size();
-		if (to > first_batch) // just count the remaining (if any)
-			total += search_lc(first_batch + 1, to, str, str_len);
-		// TODO: fix the showing highlights to work without overcounting
-		else if (to < first_batch)
-			total -= matches.back().size(); // overcounted
-	} else
-		total += search_lc(from, to, str, str_len);
+	for (auto i : occurrences)
+		total += i.len();
 
 	clear_header();
 	snprintf(lnbuf, lnbf_cpt, "%lu matches on lines [%u, %u]", total, from, to - 1);
 	print2header(lnbuf, 1);
 
-	if (mode == 'c')
+	if (mode == 'c' || total == 0)
 		return;
+	str++;
 	str_len -= mbcnt(str, str_len); // get displayed characters
 
-	// displayed x, previous byte, previous print byte, previous iterated occurrence
-	vector<uint> dix(maxy), previ(maxy), prevpr(maxy), prevx(maxy);
-	int ch = 0;
+	uint cline = 0; // cumulative line
+	vector<pair<uint,uint>> matches; // y,x
+	for (uint i = 0; i < occurrences.size(); ++i) { // occurrences in each chunk
+		for (uint j = 0; j < occurrences[i].len(); ++j) { // i.len() may be 0
+			matches.emplace_back(index2yx(occurrences[i].array[j], &first_line));
+			matches.back().first += cline;
+		}
+		append = mode == 'h';
+		cline += first_line.parent()->num_lines;
+		first_line.orig = &first_line.parent()->next->merged_lines;
+		occurrences[i].set_len(0);
+	}
+
+	reset_view();
+	scroll2(matches[0].first + 1);
+	uint cur_occ = 0; // current occurrence
+	highlight_occ(matches, 0);
+
+	y = ofx = 0;
 	curs_set(0);
-	do {
+	int ch;
+	while ((ch = wgetch(text_win))) {
 		switch (ch) {
-		case KEY_RIGHT:
-			tmp_it = it;
-			for (uint i = from; i < first_batch; ++i, ++tmp_it)
-				if (prevpr[i] != 0 && previ[i] != matches[ofy + i].back()) // more occurrences remaining
-					mvprint_line(i, 0, *tmp_it, prevpr[i], 0);
-			break;
-
-		case 0:
-		case KEY_LEFT:
-			tmp_it = it;
-			for (uint i = from; i < first_batch; ++i, ++tmp_it) {
-				mvprint_line(i, 0, *tmp_it, 0, 0);
-				dix[i] = previ[i] = prevpr[i] = prevx[i] = 0;
-			}
-			break;
-
-		case KEY_DOWN:
-			for (uint i = from; i < first_batch; ++i)
-				dix[i] = previ[i] = prevpr[i] = prevx[i] = 0;
-			if (ofy + maxy > min(text.size, to))
+		case KEY_RIGHT: // next occurrence in the same line
+			if (cur_occ == matches.size() - 1 || matches[cur_occ + 1].first != matches[cur_occ].first)
 				break;
-			++ofy;
-			++it;
-			print_text(0);
-			++tmp_it;
-			matches.emplace_back(search_a(*tmp_it, str, str_len));
+			cur_occ++;
+			mvr_scurs(matches[cur_occ].second);
 			break;
 
-		case KEY_UP:
-			for (uint i = from; i < first_batch; ++i)
-				dix[i] = previ[i] = prevpr[i] = prevx[i] = 0;
-			if (ofy <= 0)
+		case KEY_LEFT: // previous occurrence in the same line
+			if (!cur_occ || matches[cur_occ - 1].first != matches[cur_occ].first)
 				break;
-			--ofy;
-			--it;
-			print_text(0);
+			cur_occ--;
+			mvl_scurs(matches[cur_occ].second);
 			break;
 
-		case 27:
-		case 'q':
+		case KEY_DOWN: // previous occurrence in previous lines
+			if (cur_occ == matches.size() - 1 || matches[cur_occ].first == matches.back().first)
+				break;
+			cur_occ = ln_start(matches, matches[cur_occ].first + 1);
+			if (matches[cur_occ].first >= text.lines || it.global_pos + ofy - ry >= text.lines)
+				break;
+			scroll2(matches[cur_occ].first + 1);
+			if (matches[cur_occ].second >= maxx)	
+				mvr_scurs(matches[cur_occ].second); // this is dx not byte
+			iterate_fw(&it, ofy - ry);
+			break;
+
+		case KEY_UP: // next occurrence in next lines
+			if (matches[cur_occ].first == 0 || cur_occ == 0)
+				break;
+			cur_occ = ln_start(matches, matches[cur_occ].first - 1);
+			if (matches[cur_occ].first == ry)
+				cur_occ--;
+			scroll2(matches[cur_occ].first + 1);
+			iterate_bw(&it, ry - ofy);
+			break;
+
 		default:
 			goto exit;
 		}
-
-		tmp_it = it;
-		for (uint i = 0; i < first_batch; ++i, ++tmp_it) { // line
-			for (uint j = prevx[i]; j < matches[ofy + i].size(); ++j) { // occurrence
-				const uint pos = matches[ofy + i][j];
-				const uint hg_pos = bytes2dchar(pos, previ[i], *tmp_it);
-				prevx[i] = j;
-				if (dix[i] + hg_pos >= maxx - 1 + prevpr[i]) { // cut
-					prevpr[i] = pos - pos % (maxx - 1);
-					break;
-				}
-				previ[i] = pos;
-				dix[i] += hg_pos;
-				wmove(text_win, i + from, dix[i] % (maxx - 1));
-				wchgat(text_win, str_len, A_STANDOUT, 0, 0);
-			}
-		}
-	} while ((ch = wgetch(text_win)));
+		highlight_occ(matches, cur_occ);
+		ry = ofy;
+	}
 exit:
 	curs_set(1);
 	reset_view();
 }
 
-// each thread searches on chunk of lines with this
-static void _search_lc(uint from, uint to, list<gap_buf>::iterator it, const char *str, ushort str_len, uint &count)
+static void partition_chunks(uint &nthreads, uint &chunk, uint &remainder, uint len)
 {
-	for (uint i = from; i < to; ++i, ++it)
-		count += search_c(*it, str, str_len);
+	nthreads = sysconf(_SC_NPROCESSORS_ONLN);
+	chunk = len / nthreads;
+	remainder = len % nthreads;
 }
 
-// each thread searches on chunk of lines with this
-static void _search_la(uint from, uint to, list<gap_buf>::iterator it, const char *str, ushort str_len, vector<vector<uint>> &matches)
+static void bitap_search(const uchar *buf, uint blen, dynarray *matches)
 {
-	for (uint i = from; i < to; ++i, ++it) {
-		vector<uint> tmp = search_a(*it, str, str_len);
-		matches.push_back(tmp);
-	}
-}
+	uint plen = string[0]; // pascal string
+	if (blen < plen)
+		return;
+	const uchar *str = (const uchar*)string + 1;
+	uint cnt = 0;
+	// for each possible byte value, 0 where the str has match
+	ulong mask[256];
+	memset(mask, -1, sizeof(mask));
 
-static void partition_chunks(uint &nthreads, uint &chunk, uint from, uint to)
-{
-	nthreads = thread::hardware_concurrency();
-	if (nthreads == 0 || to - from < (uint)1e6)
-		nthreads = 1;
-	chunk = (to - from + 1) / nthreads;
-}
+	// for each position i in buf, bit i = 0 in mask[buf[i]]
+	for (uint i = 0; i < plen; i++)
+		mask[str[i]] &= ~(1ul << i);
 
-static void join_threads(vector<thread> &threads)
-{
-	for (auto &thread : threads)
-		if (thread.joinable())
-			thread.join();
-}
+	ulong state = -1; // no matches
+	ulong accept_bit = 1ul << plen;
 
-// search for str in range [from, to) return occurrences
-vector<vector<uint>> search_la(uint from, uint to, const char *str, ushort str_len)
-{
-	uint nthreads, chunk;
-	partition_chunks(nthreads, chunk, from, to);
-	vector<thread> threads(nthreads);
-	vector<vector<vector<uint>>> indices(nthreads);
+	for (uint i = 0; i < blen; i++) {
+		state = (state | mask[buf[i]]) << 1ul;
 
-	list<gap_buf>::iterator tmp_it = text.begin();
-	advance(tmp_it, from);
-	for (uint i = 0; i < nthreads; ++i) {
-		uint st = i * chunk;
-		uint end = min((i + 1) * chunk, to);
-
-		threads.emplace_back(_search_la, st, end, tmp_it, str, str_len, ref(indices[i]));
-		advance(tmp_it, chunk);
-	}
-	join_threads(threads);
-	// merge results (each threads' chunks to one vector)
-	vector<vector<uint>> result;
-	for (vector<vector<uint>> &vec : indices)
-		result.insert(result.end(), vec.begin(), vec.end());
-	return result;
-}
-
-// search for str in range [from, to)
-ulong search_lc(uint from, uint to, const char *str, ushort str_len)
-{
-	uint nthreads, chunk;
-	partition_chunks(nthreads, chunk, from, to);
-	vector<thread> threads(nthreads);
-	vector<uint> indices(nthreads);
-
-	list<gap_buf>::iterator tmp_it = text.begin();
-	advance(tmp_it, from);
-	for (uint i = 0; i < nthreads; ++i) {
-		uint st = i * chunk;
-		uint end = min((i + 1) * chunk, to);
-
-		threads.emplace_back(_search_lc, st, end, tmp_it, str, str_len, ref(indices[i]));
-		advance(tmp_it, chunk);
-	}
-	join_threads(threads);
-
-	ulong total = 0;
-	for (uint tmp : indices)
-		total += tmp;
-	return total;
-}
-
-static uchar *_badchar(const char *str, uchar len)
-{
-	uchar *badchar = (uchar*)malloc(256);
-	for (uint i = 0; i < 256; ++i) // BMH table
-		badchar[i] = len;
-	for (uint i = 0; i < len; i++)
-		badchar[(uchar)str[i]] = len - i - 1;
-
-	return badchar;
-}
-
-static uint *_goodsuffix(const char *str, ushort len)
-{
-	uint *gs = (uint*)malloc(len * sizeof(uint));
-	int *pos = (int*)malloc(len * sizeof(int));
-	fill(pos, pos + len, -1);
-
-	for (uint i = 1; i < len; i++) {
-		int j = pos[i - 1];
-		while (j >= 0 && str[i] != str[j])
-			j = pos[j];
-		pos[i] = j + 1;
-	}
-
-	gs[0] = len;
-	for (uint i = 1; i < len; i++)
-		gs[i] = len - pos[i];
-
-	for (uint i = len - 1; i > 0; i--) {
-		if (str[i] != str[pos[i]])
-			gs[i] = len - i;
-		else
-			gs[i] = gs[pos[i]];
-	}
-	free(pos);
-	return gs;
-}
-
-static vector<uint> bm_search(const gap_buf &buf, const char *str, ushort len, bool append)
-{
-	vector<uint> matches;
-	uint count = 0;
-	// heuristics
-	uchar *badchar = _badchar(str, len);
-	uint *goodsuffix = _goodsuffix(str, len);
-
-	for (uint i = 0; i < buf.len() - len;) {
-		uint j;
-
-		// check from end of str
-		for (j = len - 1; j < len && str[j] == at(buf, i + j); --j);
-
-		if (j > len) { // unsigned overflow => matched
-			if (append) // this wasn't a bottleneck in benchmarks (maybe retest?)
-				matches.push_back(i);
+		// matched all plen bits in sequence
+		if ((state & accept_bit) == 0) {
+			if (append)
+				matches->append(i + 1 - plen);
 			else
-				++count;
-			i += len; // no overlaps
-		} else
-			i += max(badchar[(uchar)at(buf, i + j)], goodsuffix[j]);
-	}
-	free(goodsuffix);
-	free(badchar);
-	if (!append)
-		matches.push_back(count);
-	return matches;
-}
-
-// each thread searches with this
-static void searchch_a(const gap_buf &buf, char ch, ulong st, ulong end, vector<uint> &matches)
-{
-	ulong st1 = st, st2, end1 = end, end2 = 0;
-	const char *buffer = buf.buffer();
-	prepare_iteration(buf, st, end, st1, end1, st2, end2);
-	for (ulong i = st1; i < end1; ++i)
-		if (buffer[i] == ch)
-			matches.push_back(i - st1 + st);
-	for (ulong i = st2; i < end2; ++i)
-		if (buffer[i] == ch)
-			matches.push_back(i - st2 + st);
-}
-
-// each thread searches with this
-static void searchch_c(const gap_buf &buf, char ch, ulong st, ulong end, uint &count)
-{
-	ulong st1, end1, st2, end2;
-	const char *buffer = buf.buffer();
-	prepare_iteration(buf, st, end, st1, end1, st2, end2);
-	for (ulong i = st1; i < end1; ++i)
-		if (buffer[i] == ch)
-			++count;
-	for (ulong i = st2; i < end2; ++i)
-		if (buffer[i] == ch)
-			++count;
-}
-
-// wrapper for searchch() to launch with multi-threaded
-vector<uint> mt_search(const gap_buf &buf, char ch, bool append)
-{
-	uint nthreads, chunk;
-	// TODO: partition smarter: before gap + after gap
-	partition_chunks(nthreads, chunk, 0, buf.len() - 1); // -1 as last char is \n
-	vector<thread> threads(nthreads);
-	vector<vector<uint>> indices(nthreads); // each thread's result
-
-	for (uint i = 0; i < nthreads; ++i) {
-		ulong st = i * chunk;
-		ulong end = min((i + 1) * chunk, buf.len() - 1);
-
-		if (append)
-			threads.emplace_back(searchch_a, ref(buf), ch, st, end, ref(indices[i]));
-		else {
-			indices[i].push_back(0);
-			threads.emplace_back(searchch_c, ref(buf), ch, st, end, ref(indices[i][0]));
+				matches->incr_len();
 		}
 	}
-	join_threads(threads);
+}
 
-	vector<uint> matches;
-	matches.reserve(indices[0].size());
-	if (append)
-		for (const auto &vec : indices)
-			matches.insert(matches.end(), vec.begin(), vec.end());
-	else {
-		matches.push_back(0);
-		for (const auto &vec : indices)
-			matches[0] += vec[0];
+static void mid_search(const char *buf, dynarray *matches, uint midlen)
+{
+	const uint plen = string[0];
+	const char *str = string + 1;
+	// an occurrence might be split between gap start and gap end
+	const uint midpoint = plen - 1;
+	// if st underflows, it becomes: 2^32-x (which is always) > gps, so loop never gets executed
+	for (uint i = 0; i < midpoint; ++i) {
+		bool a, b;
+		a = strncmp(buf + i, str, midpoint - i);
+		if (a)
+			b = strncmp(buf + midpoint + midlen, str + i, midpoint + midlen - i);
+
+		if ((a & b) == 0) {
+			if (append)
+				matches->append(i);
+			else
+				matches->incr_len();
+			break; // only one match can fit between the gap
+		}
 	}
-	return matches;
 }
 
-// search for str in buf, return vector of occurences
-vector<uint> search_a(const gap_buf &buf, const char *str, ushort len)
+// search for str in buf, return vector of occurrences
+static void searchstr(dynarray *matches, const gap_buf *buf)
 {
-	vector<uint> matches;
-	if (len >= buf.len())
-		return matches;
+	if (string[0] >= buf->len())
+		return;
 
-	if (len == 1)
-		matches = mt_search(buf, str[0], 1);
-	else
-		matches = bm_search(buf, str, len, 1);
+	uint end1 = buf->gps; // for clarity
+	uint st2 = buf->gpe + 1, end2 = buf->cpt();
 
-	return matches;
+	bitap_search((uchar*)buf->buffer(), end1, matches);
+	if (end2 - st2 > 1) // if only 1 char is left it is the newline
+		mid_search(buf->buffer() + end1 + 1 - string[0], matches, st2 - end1);
+	bitap_search((uchar*)buf->buffer() + st2, end2 - st2, matches);
 }
 
-uint search_c(const gap_buf &buf, const char *str, ushort len)
+static void ranged_searchstr(dynarray *matches, const gap_buf *buf, uint from, uint to)
 {
-	if (len >= buf.len())
-		return 0;
+	uint from1, from2, to1, to2;
+	prepare_iteration(buf, from, to, from1, to1, from2, to2);
+	bitap_search((uchar*)buf->buffer() + from1, to1 - from1, matches);
+	if (to2 > from2) {
+		mid_search(buf->buffer(), matches, to2 - to1 + 1);
+		bitap_search((uchar*)buf->buffer() + from2, to2 - from2, matches);
+	}
+}
 
-	vector<uint> matches;
-	if (len == 1)
-		matches = mt_search(buf, str[0], 0);
-	else
-		matches = bm_search(buf, str, len, 0);
-	return matches[0];
+// String search
+
+// arguments for each thread (shared for count/append)
+struct args_str {
+	chunk *lines;
+	uint count; // count of chunks to process
+	uint out; // array of matches or pointer to count
+};
+
+static void search_mb_common(uint from, uint to, void *search_fn(void*))
+{
+	// first chunk may need an offset for start
+	point2begin(&first_line);
+	iterate_fw(&first_line, from);
+	chunk *chi = first_line.parent();
+
+	uint cur_ln = first_line.global_pos, num_chunks = 0;
+	cur_ln += chi->num_lines;
+	while (cur_ln < to) {
+		chi = chi->next;
+		cur_ln += chi->num_lines;
+		num_chunks++;
+	}
+	// last chunk may need reduced length
+	point2chunk(&last_line, chi);
+	line_offset(&last_line, cur_ln - to);
+	if (num_chunks == 0) {
+		ranged_searchstr(&occurrences[0], first_line.orig, first_line.offset, last_line.offset + last_line.len());
+		return;
+	}
+	last_line.global_pos = to;
+	chi = first_line.parent()->next;
+	// it's probably better to directly call these than doing an ugly combination of goto and if
+	if (num_chunks == 1) {
+		ranged_searchstr(&occurrences[0], first_line.orig, first_line.offset, first_line.orig->len());
+		ranged_searchstr(&occurrences[1], last_line.orig, 0, last_line.len());
+		return;
+	}
+
+	uint nthreads = num_chunks < 256 ? 1 : sysconf(_SC_NPROCESSORS_ONLN);
+	occurrences.resize(append ? num_chunks : nthreads);
+	num_chunks--; // first and last chunk are processed independently
+	uint chunk_sz = num_chunks / nthreads;
+	uint remainder = num_chunks % nthreads;
+
+	pthread_t *threads = (pthread_t*)malloc(nthreads * sizeof(pthread_t));
+	struct args_str *args = (struct args_str*)malloc(nthreads * sizeof(struct args_str));
+	for (uint i = 0; i < nthreads; ++i) {
+		uint st = i * chunk_sz;
+		uint size = chunk_sz + (i == nthreads - 1 ? remainder : 0);
+
+		args[i].count = size;
+		args[i].lines = chi;
+		args[i].out = st + 1;
+
+		pthread_create(&threads[i], nullptr, search_fn, &args[i]);
+		while (size--)
+			chi = chi->next;
+	}
+
+	// first and last lines are special cases and thus processed by main thread
+	ranged_searchstr(&occurrences[0], first_line.orig, first_line.offset, first_line.orig->len());
+	ranged_searchstr(&occurrences[num_chunks], last_line.orig, 0, last_line.len());
+
+	for (uint i = 0; i < nthreads; ++i)
+		pthread_join(threads[i], nullptr);
+	free(threads);
+	free(args);
+}
+
+// each thread searches on chunk of nodes with this
+static void *_search_lc(void *args)
+{
+	struct args_str *a = (struct args_str*)args;
+	uint count = 0;
+
+	for (uint i = 0; i < a->count; ++i) {
+		occurrences[a->out].set_len(0); // reset previous search
+		searchstr(&occurrences[a->out], &a->lines->merged_lines);
+		count += occurrences[a->out].array[0];
+		a->lines = a->lines->next;
+	}
+	occurrences[a->out].set_len(count);
+	return nullptr;
+}
+
+// each thread searches on chunk of nodes with this
+static void *_search_la(void *arg)
+{
+	struct args_str *a = (struct args_str*)arg;
+
+	for (uint i = 0; i < a->count; ++i) {
+		occurrences[a->out].set_len(0); // reset previous search
+		searchstr(&occurrences[a->out], &a->lines->merged_lines);
+		a->out++; // next chunk in occurrences[]
+		a->lines = a->lines->next;
+	}
+	return nullptr;
 }

--- a/utils/search.cpp
+++ b/utils/search.cpp
@@ -159,21 +159,14 @@ exit:
 	reset_view();
 }
 
-static void partition_chunks(uint &nthreads, uint &chunk, uint &remainder, uint len)
-{
-	nthreads = sysconf(_SC_NPROCESSORS_ONLN);
-	chunk = len / nthreads;
-	remainder = len % nthreads;
-}
-
 static void bitap_search(const uchar *buf, uint blen, dynarray *matches)
 {
 	uint plen = string[0]; // pascal string
 	if (blen < plen)
 		return;
 	const uchar *str = (const uchar*)string + 1;
-	uint cnt = 0;
-	// for each possible byte value, 0 where the str has match
+
+	// for each byte value, 0 where the str has match
 	ulong mask[256];
 	memset(mask, -1, sizeof(mask));
 

--- a/utils/sizes.cpp
+++ b/utils/sizes.cpp
@@ -16,7 +16,7 @@ char hrsize(size_t bytes, char *dest, ushort dest_cpt)
 	return suffix[i];
 }
 
-// helper function for calc_offset_[dis|act](), dchar2bytes()
+// helper function for calculating offsets
 static void get_off(ulong &x, ulong &i, const gap_buf &buf)
 {
 	char ch = at(buf, i);
@@ -29,22 +29,25 @@ static void get_off(ulong &x, ulong &i, const gap_buf &buf)
 }
 
 // displayed characters to bytes, flag -> disp_x where counting stopped at
-ulong dchar2bytes(ulong disp_x, ulong from, const gap_buf &buf)
+ulong dchar2bytes(ulong disp_x, ulong from, const iter *i)
 {
+	from += i->offset;
 	ulong x = 0;
-	while (x < disp_x && from < buf.len())
-		get_off(x, from, buf);
+	while (x < disp_x && from < i->orig->len())
+		get_off(x, from, *i->orig);
 	flag = x;
-	return from;
+	return from - i->offset;
 }
 
 // bytes to displayed characters, flag -> bytes of x returned
-ulong bytes2dchar(ulong bytes, ulong from, const gap_buf &buf)
+ulong bytes2dchar(ulong bytes, ulong from, const iter *i)
 {
+	from += i->offset;
+	bytes += i->offset;
 	ulong x = 0;
 	while (from < bytes)
-		get_off(x, from, buf);
-	flag = from;
+		get_off(x, from, *i->orig);
+	flag = from - i->offset;
 	return x;
 }
 
@@ -61,7 +64,7 @@ ulong mbcnt(const char *str, ulong len)
 // currently on a tab; go to previous char
 uint prevdchar()
 {
-	long prev_ofx = calc_offset_dis(x - 8, *it);
+	long prev_ofx = calc_offset_dis(x - 8, 0, &it);
 	long diff = prev_ofx - ofx;
 	wmove(text_win, y, x - diff - 1);
 	return diff;

--- a/utils/sizes.cpp
+++ b/utils/sizes.cpp
@@ -17,7 +17,7 @@ char hrsize(size_t bytes, char *dest, ushort dest_cpt)
 }
 
 // helper function for calculating offsets
-static void get_off(ulong &x, ulong &i, const gap_buf &buf)
+static void get_off(uint &x, uint &i, const gap_buf &buf)
 {
 	char ch = at(buf, i);
 	if (ch == '\t')
@@ -29,10 +29,10 @@ static void get_off(ulong &x, ulong &i, const gap_buf &buf)
 }
 
 // displayed characters to bytes, flag -> disp_x where counting stopped at
-ulong dchar2bytes(ulong disp_x, ulong from, const iter *i)
+uint dchar2bytes(uint disp_x, uint from, const iter *i)
 {
 	from += i->offset;
-	ulong x = 0;
+	uint x = 0;
 	while (x < disp_x && from < i->orig->len())
 		get_off(x, from, *i->orig);
 	flag = x;
@@ -40,11 +40,11 @@ ulong dchar2bytes(ulong disp_x, ulong from, const iter *i)
 }
 
 // bytes to displayed characters, flag -> bytes of x returned
-ulong bytes2dchar(ulong bytes, ulong from, const iter *i)
+uint bytes2dchar(uint bytes, uint from, const iter *i)
 {
 	from += i->offset;
 	bytes += i->offset;
-	ulong x = 0;
+	uint x = 0;
 	while (from < bytes)
 		get_off(x, from, *i->orig);
 	flag = from - i->offset;
@@ -52,10 +52,10 @@ ulong bytes2dchar(ulong bytes, ulong from, const iter *i)
 }
 
 // count multi-byte characters in string
-ulong mbcnt(const char *str, ulong len)
+uint mbcnt(const char *str, uint len)
 {
-	ulong count = 0; // multi-byte char
-	for (ulong i = 0; i < len && str[i] != 0; ++i)
+	uint count = 0; // multi-byte char
+	for (uint i = 0; i < len && str[i] != 0; ++i)
 		if (str[i] < 0)
 			count++;
 	return count / 2; // only 2-byte multibyte chars are supported


### PR DESCRIPTION
This is a new data structure specifically designed for text editors. Kri and other editors use a gap buffer to store text. Emacs uses a single gap buffer for the whole file, while kri used a different buffer for each line, and each line was a node of a linked list.
The advantage of using a different buffer for each line is the speed to insert at any arbitrary position. Emacs has to move the gap across the entire file size just to insert a character at EOF. Kri would instantly go to the tail of the list and move the gap only on the line, not all the text.
The problem with kri's approach is that in the worst case where each line is just a byte long, there is too much memory overhead (>20x) and fragmentation.

This new data structure merges small (<256B) lines into a single buffer, which eliminates memory fragmentation and significantly reduces the overhead (max ~1.5x). As kri is a line oriented text editor, functions expect an iterator that points to a specific gap buffer, but now multiple lines are in the same gap buffer. To solve this, each iterator emulates being a standalone gap buffer by storing the offset, and using it to calculate the differences.
